### PR TITLE
Add support for authentication token

### DIFF
--- a/cloudscale.go
+++ b/cloudscale.go
@@ -27,6 +27,9 @@ type Client struct {
 	// Base URL for API requests.
 	BaseURL *url.URL
 
+	// Authentication token
+	AuthToken string
+
 	// User agent for client
 	UserAgent string
 
@@ -73,6 +76,11 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body int
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
 	req.Header.Add("User-Agent", c.UserAgent)
+
+	if len(c.AuthToken) != 0 {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.AuthToken))
+	}
+
 	return req, nil
 }
 

--- a/cloudscale_test.go
+++ b/cloudscale_test.go
@@ -79,6 +79,25 @@ func TestNewRequest(t *testing.T) {
 	if c.UserAgent != userAgent {
 		t.Errorf("NewRequest() User-Agent = %v, expected %v", userAgent, c.UserAgent)
 	}
+
+	authz := req.Header.Get("Authorization")
+	if len(authz) != 0 {
+		t.Errorf("NewReader() Authorization = %v, expected none", authz)
+	}
+}
+
+func TestNewRequestWithToken(t *testing.T) {
+	c := NewClient(nil)
+	c.AuthToken = "HELPIMTRAPPEDINATOKENGENERATOR"
+
+	inBody := &ServerRequest{Name: "l"}
+	req, _ := c.NewRequest(ctx, http.MethodGet, "/", inBody)
+
+	expected := "Bearer " + c.AuthToken
+	authz := req.Header.Get("Authorization")
+	if authz != expected {
+		t.Errorf("NewReader() Authorization = %v, expected %v", authz, expected)
+	}
 }
 
 func TestErrorResponse_Error(t *testing.T) {


### PR DESCRIPTION
The Cloudscale API[1] supports the use of authentication tokens passed
via the "Authorization" header. Allow their use in the Go client. If not
specified the previous behaviour is preserved (necessary, for example,
for OAuth2).

[1] https://www.cloudscale.ch/en/api/v1