### PR TITLE
Include API status code in error structure

### DIFF
--- a/cloudscale.go
+++ b/cloudscale.go
@@ -136,12 +136,14 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	return &ErrorResponse{
-		Message: res,
+		StatusCode: r.StatusCode,
+		Message:    res,
 	}
 }
 
 type ErrorResponse struct {
-	Message map[string]string
+	StatusCode int
+	Message    map[string]string
 }
 
 func (r *ErrorResponse) Error() string {

--- a/cloudscale_test.go
+++ b/cloudscale_test.go
@@ -120,6 +120,7 @@ func TestCheckResponse(t *testing.T) {
 	}
 
 	expected := &ErrorResponse{
+		StatusCode: http.StatusBadRequest,
 		Message: map[string]string{
 			"name": "This field may not be blank.",
 		},


### PR DESCRIPTION
Access to the original API status code (i.e. 401 for an invalid token)
allows a caller to handle failures more gracefully, i.e. by retrying
temporary errors.