### PR TITLE
add createdAt field

### DIFF
--- a/custom_images.go
+++ b/custom_images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const customImagesBasePath = "v1/custom-images"
@@ -24,6 +25,7 @@ type CustomImage struct {
 	Checksums        map[string]string `json:"checksums,omitempty"`
 	UserDataHandling string            `json:"user_data_handling,omitempty"`
 	Zones            []Zone            `json:"zones"`
+	CreatedAt        time.Time         `json:"created_at"`
 }
 
 type CustomImageRequest struct {

--- a/custom_images_test.go
+++ b/custom_images_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestCustomImage_Get(t *testing.T) {
@@ -14,7 +15,7 @@ func TestCustomImage_Get(t *testing.T) {
 
 	mux.HandleFunc("/v1/custom-images/11111111-1864-4608-853a-0771b6885a3a", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"uuid": "11111111-1864-4608-853a-0771b6885a3a"}`)
+		fmt.Fprint(w, `{"uuid": "11111111-1864-4608-853a-0771b6885a3a", "created_at": "2019-05-27T16:45:32.241824Z"}`)
 	})
 
 	objectUser, err := client.CustomImages.Get(ctx, "11111111-1864-4608-853a-0771b6885a3a")
@@ -22,7 +23,7 @@ func TestCustomImage_Get(t *testing.T) {
 		t.Errorf("CustomImage.Get returned error: %v", err)
 	}
 
-	expected := &CustomImage{UUID: "11111111-1864-4608-853a-0771b6885a3a"}
+	expected := &CustomImage{UUID: "11111111-1864-4608-853a-0771b6885a3a", CreatedAt: time.Date(2019, time.Month(5), 27, 16, 45, 32, 241824000, time.UTC) }
 	if !reflect.DeepEqual(objectUser, expected) {
 		t.Errorf("CustomImage.Get\n got=%#v\nwant=%#v", objectUser, expected)
 	}

--- a/floating_ips.go
+++ b/floating_ips.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"strconv"
+	"time"
 )
 
 const floatingIPsBasePath = "v1/floating-ips"
@@ -20,6 +21,7 @@ type FloatingIP struct {
 	Server         *ServerStub `json:"server"`
 	Type           string      `json:"type"`
 	ReversePointer string      `json:"reverse_ptr,omitempty"`
+	CreatedAt      time.Time   `json:"created_at"`
 }
 
 type FloatingIPCreateRequest struct {

--- a/floating_ips_test.go
+++ b/floating_ips_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestFloatingIPs_IP(t *testing.T) {
@@ -65,7 +66,7 @@ func TestFloatingIPs_Get(t *testing.T) {
 
 	mux.HandleFunc("/v1/floating-ips/192.0.2.123", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"network": "192.0.2.123/32"}`)
+		fmt.Fprint(w, `{"network": "192.0.2.123/32", "created_at": "2019-05-27T16:45:32.241824Z"}`)
 	})
 
 	floatingIP, err := client.FloatingIPs.Get(ctx, "192.0.2.123")
@@ -73,7 +74,7 @@ func TestFloatingIPs_Get(t *testing.T) {
 		t.Errorf("FloatingIPs.Get returned error: %v", err)
 	}
 
-	expected := &FloatingIP{Network: "192.0.2.123/32"}
+	expected := &FloatingIP{Network: "192.0.2.123/32", CreatedAt: time.Date(2019, time.Month(5), 27, 16, 45, 32, 241824000, time.UTC)}
 	if !reflect.DeepEqual(floatingIP, expected) {
 		t.Errorf("FloatingIPs.Get\n got=%#v\nwant=%#v", floatingIP, expected)
 	}

--- a/networks.go
+++ b/networks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const networkBasePath = "v1/networks"
@@ -13,11 +14,12 @@ type Network struct {
 	TaggedResource
 	// Just use omitempty everywhere. This makes it easy to use restful. Errors
 	// will be coming from the API if something is disabled.
-	HREF    string       `json:"href,omitempty"`
-	UUID    string       `json:"uuid,omitempty"`
-	Name    string       `json:"name,omitempty"`
-	MTU     int          `json:"mtu,omitempty"`
-	Subnets []SubnetStub `json:"subnets"`
+	HREF      string       `json:"href,omitempty"`
+	UUID      string       `json:"uuid,omitempty"`
+	Name      string       `json:"name,omitempty"`
+	MTU       int          `json:"mtu,omitempty"`
+	Subnets   []SubnetStub `json:"subnets"`
+	CreatedAt time.Time    `json:"created_at"`
 }
 
 type NetworkStub struct {

--- a/networks_test.go
+++ b/networks_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNetworks_Create(t *testing.T) {
@@ -51,7 +52,7 @@ func TestNetworks_Get(t *testing.T) {
 
 	mux.HandleFunc("/v1/networks/cfde831a-4e87-4a75-960f-89b0148aa2cc", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"uuid": "cfde831a-4e87-4a75-960f-89b0148aa2cc"}`)
+		fmt.Fprint(w, `{"uuid": "cfde831a-4e87-4a75-960f-89b0148aa2cc", "created_at": "2019-05-27T16:45:32.241824Z"}`)
 	})
 
 	network, err := client.Networks.Get(ctx, "cfde831a-4e87-4a75-960f-89b0148aa2cc")
@@ -59,7 +60,7 @@ func TestNetworks_Get(t *testing.T) {
 		t.Errorf("Networks.Get returned error: %v", err)
 	}
 
-	expected := &Network{UUID: "cfde831a-4e87-4a75-960f-89b0148aa2cc"}
+	expected := &Network{UUID: "cfde831a-4e87-4a75-960f-89b0148aa2cc", CreatedAt: time.Date(2019, time.Month(5), 27, 16, 45, 32, 241824000, time.UTC)}
 	if !reflect.DeepEqual(network, expected) {
 		t.Errorf("Networks.Get\n got=%#v\nwant=%#v", network, expected)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestServers_Create(t *testing.T) {
@@ -60,7 +61,7 @@ func TestServers_Get(t *testing.T) {
 
 	mux.HandleFunc("/v1/servers/cfde831a-4e87-4a75-960f-89b0148aa2cc", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"uuid": "cfde831a-4e87-4a75-960f-89b0148aa2cc"}`)
+		fmt.Fprint(w, `{"uuid": "cfde831a-4e87-4a75-960f-89b0148aa2cc", "created_at": "2019-05-27T16:45:32.241824Z"}`)
 	})
 
 	server, err := client.Servers.Get(ctx, "cfde831a-4e87-4a75-960f-89b0148aa2cc")
@@ -68,7 +69,7 @@ func TestServers_Get(t *testing.T) {
 		t.Errorf("Server.Get returned error: %v", err)
 	}
 
-	expected := &Server{UUID: "cfde831a-4e87-4a75-960f-89b0148aa2cc"}
+	expected := &Server{UUID: "cfde831a-4e87-4a75-960f-89b0148aa2cc", CreatedAt: time.Date(2019, time.Month(5), 27, 16, 45, 32, 241824000, time.UTC)}
 	if !reflect.DeepEqual(server, expected) {
 		t.Errorf("Servers.Get\n got=%#v\nwant=%#v", server, expected)
 	}

--- a/servers.go
+++ b/servers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"time"
 )
 
 const serverBasePath = "v1/servers"
@@ -28,6 +29,7 @@ type Server struct {
 	SSHHostKeys     []string          `json:"ssh_host_keys"`
 	AntiAfinityWith []ServerStub      `json:"anti_affinity_with"`
 	ServerGroups    []ServerGroupStub `json:"server_groups"`
+	CreatedAt       time.Time         `json:"created_at"`
 }
 
 type ServerStub struct {

--- a/test/integration/custom_image_integration_test.go
+++ b/test/integration/custom_image_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
@@ -11,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 )
 
 const testImageURL = "https://at-images.objects.lpg.cloudscale.ch/alpine"
@@ -59,6 +61,10 @@ func TestIntegrationCustomImage_CRUD(t *testing.T) {
 		t.Errorf("CustomImage.List got=%d\nwant=%d\n", numCustomImages, 1)
 	}
 
+	if h := time.Since(customImages[0].CreatedAt).Hours(); !(-1 < h && h < 1) {
+		t.Errorf("customImages[0].CreatedAt ourside of expected range. got=%v", customImages[0].CreatedAt)
+	}
+
 	customImageImports, err := client.CustomImageImports.List(context.Background())
 	if err != nil {
 		t.Fatalf("CustomImageImports.List returned error %s\n", err)
@@ -69,6 +75,7 @@ func TestIntegrationCustomImage_CRUD(t *testing.T) {
 	}
 
 	customImage, err := client.CustomImages.Get(context.Background(), customImageImport.CustomImage.UUID)
+
 	if err != nil {
 		t.Fatalf("CustomImages.Get returned error %s\n", err)
 	}

--- a/test/integration/floating_ip_integration_test.go
+++ b/test/integration/floating_ip_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
@@ -7,6 +8,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cloudscale-ch/cloudscale-go-sdk"
 )
@@ -41,6 +43,10 @@ func TestIntegrationFloatingIP_CRUD(t *testing.T) {
 	expectedIP, err := client.FloatingIPs.Create(context.TODO(), createFloatingIPRequest)
 	if err != nil {
 		t.Fatalf("floatingIP.Create returned error %s\n", err)
+	}
+
+	if h := time.Since(expectedIP.CreatedAt).Hours(); !(-1 < h && h < 1) {
+		t.Errorf("expectedIP.CreatedAt ourside of expected range. got=%v", expectedIP.CreatedAt)
 	}
 
 	if uuid := expectedIP.Server.UUID; uuid != server.UUID {
@@ -400,10 +406,8 @@ func TestIntegrationFloatingIP_WithoutServer(t *testing.T) {
 		t.Errorf("FloatingIPs.List \n got=%d\nwant=%d", numFloatingIps, 1)
 	}
 
-
 	err = client.FloatingIPs.Delete(context.Background(), ip)
 	if err != nil {
 		t.Fatalf("FloatingIPs.Delete returned error %s\n", err)
 	}
 }
-

--- a/test/integration/network_integration_test.go
+++ b/test/integration/network_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
@@ -31,6 +32,10 @@ func TestIntegrationNetwork_CRUD(t *testing.T) {
 
 	if uuid := network.UUID; uuid != expected.UUID {
 		t.Errorf("Network.UUID got=%s\nwant=%s", uuid, expected.UUID)
+	}
+
+	if h := time.Since(network.CreatedAt).Hours(); !(-1 < h && h < 1) {
+		t.Errorf("network.CreatedAt ourside of expected range. got=%v", network.CreatedAt)
 	}
 
 	expectedNumberOfSubnets := 1
@@ -83,7 +88,7 @@ func TestIntegrationNetwork_CreateAttached(t *testing.T) {
 
 	autoCreateSubnet := false
 	createNetworkRequest := &cloudscale.NetworkCreateRequest{
-		Name: testRunPrefix,
+		Name:                 testRunPrefix,
 		AutoCreateIPV4Subnet: &autoCreateSubnet,
 	}
 	network, err := client.Networks.Create(context.TODO(), createNetworkRequest)
@@ -93,7 +98,7 @@ func TestIntegrationNetwork_CreateAttached(t *testing.T) {
 
 	createSubnetRequest := &cloudscale.SubnetCreateRequest{
 		Network: network.UUID,
-		CIDR: "192.168.42.0/24",
+		CIDR:    "192.168.42.0/24",
 	}
 	subnet, err := client.Subnets.Create(context.TODO(), createSubnetRequest)
 	if err != nil {
@@ -163,7 +168,7 @@ func TestIntegrationNetwork_CreateAttached(t *testing.T) {
 			if numNetworks := len(server.Interfaces); numNetworks != tt.expectedNumNetworks {
 				t.Errorf("Attatched to number of Networks\ngot=%#v\nwant=%#v", numNetworks, tt.expectedNumNetworks)
 			}
-			lastNetworkInterface := server.Interfaces[len(server.Interfaces)-1];
+			lastNetworkInterface := server.Interfaces[len(server.Interfaces)-1]
 			if lastNetworkInterface.Network.UUID != network.UUID {
 				t.Errorf("Attatched to wrong Network\ngot=%#v\nwant=%#v", lastNetworkInterface.Network.UUID, network.UUID)
 			}
@@ -364,7 +369,6 @@ func TestIntegrationNetwork_Reorder(t *testing.T) {
 		t.Fatalf("Networks.Delete returned error %s\n", err)
 	}
 }
-
 
 func TestIntegrationNetwork_Update(t *testing.T) {
 

--- a/test/integration/server_integration_test.go
+++ b/test/integration/server_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
@@ -50,6 +51,10 @@ func TestIntegrationServer_CRUD(t *testing.T) {
 
 	if uuid := server.UUID; uuid != expected.UUID {
 		t.Errorf("Server.UUID got=%s\nwant=%s", uuid, expected.UUID)
+	}
+
+	if h := time.Since(server.CreatedAt).Hours(); !(-1 < h && h < 1) {
+		t.Errorf("server.CreatedAt ourside of expected range. got=%v", server.CreatedAt)
 	}
 
 	servers, err := client.Servers.List(context.Background())

--- a/test/integration/volume_integration_test.go
+++ b/test/integration/volume_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration
@@ -42,6 +43,10 @@ func TestIntegrationVolume_CreateAttached(t *testing.T) {
 	volume, err := client.Volumes.Create(context.TODO(), createVolumeRequest)
 	if err != nil {
 		t.Fatalf("Volumes.Create returned error %s\n", err)
+	}
+
+	if h := time.Since(volume.CreatedAt).Hours(); !(-1 < h && h < 1) {
+		t.Errorf("volume.CreatedAt ourside of expected range. got=%v", volume.CreatedAt)
 	}
 
 	time.Sleep(3 * time.Second)
@@ -180,7 +185,6 @@ func TestIntegrationVolume_ListByName(t *testing.T) {
 		t.Fatalf("Volumes.Delete returned error %s\n", err)
 	}
 }
-
 
 func TestIntegrationVolume_MultiSite(t *testing.T) {
 	integrationTest(t)

--- a/volumes.go
+++ b/volumes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const volumeBasePath = "v1/volumes"
@@ -19,6 +20,7 @@ type Volume struct {
 	SizeGB      int       `json:"size_gb,omitempty"`
 	Type        string    `json:"type,omitempty"`
 	ServerUUIDs *[]string `json:"server_uuids,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 type VolumeRequest struct {


### PR DESCRIPTION
* add `createdAt` field to supported cloudscale ressources (`custom_images`, `floating_ips`, `networks`, `servers` and `volumes`)
* update tests