### PR TITLE
Use debian-11 Image in Tests

### DIFF
--- a/test/integration/servers_integration_test.go
+++ b/test/integration/servers_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudscale-ch/cloudscale-go-sdk/v3"
 )
 
-const DefaultImageSlug = "debian-9"
+const DefaultImageSlug = "debian-11"
 
 func integrationTest(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Debian 9 was retired a few days ago.