### PR TITLE
Add LB Stubs to LB Resources

### DIFF
--- a/load_balancer_health_monitors.go
+++ b/load_balancer_health_monitors.go
@@ -13,6 +13,7 @@ type LoadBalancerHealthMonitor struct {
 	HREF          string                         `json:"href,omitempty"`
 	UUID          string                         `json:"uuid,omitempty"`
 	Pool          LoadBalancerPoolStub           `json:"pool,omitempty"`
+	LoadBalancer  LoadBalancerStub               `json:"load_balancer,omitempty"`
 	DelayS        int                            `json:"delay_s,omitempty"`
 	TimeoutS      int                            `json:"timeout_s,omitempty"`
 	UpThreshold   int                            `json:"up_threshold,omitempty"`

--- a/load_balancer_listeners.go
+++ b/load_balancer_listeners.go
@@ -20,6 +20,7 @@ type LoadBalancerListener struct {
 	UUID                   string               `json:"uuid,omitempty"`
 	Name                   string               `json:"name,omitempty"`
 	Pool                   LoadBalancerPoolStub `json:"pool,omitempty"`
+	LoadBalancer           LoadBalancerStub     `json:"load_balancer,omitempty"`
 	Protocol               string               `json:"protocol,omitempty"`
 	ProtocolPort           int                  `json:"protocol_port,omitempty"`
 	AllowedCIDRs           []string             `json:"allowed_cidrs,omitempty"`

--- a/load_balancer_listeners.go
+++ b/load_balancer_listeners.go
@@ -16,18 +16,18 @@ type LoadBalancerListener struct {
 	TaggedResource
 	// Just use omitempty everywhere. This makes it easy to use restful. Errors
 	// will be coming from the API if something is disabled.
-	HREF                   string               `json:"href,omitempty"`
-	UUID                   string               `json:"uuid,omitempty"`
-	Name                   string               `json:"name,omitempty"`
-	Pool                   LoadBalancerPoolStub `json:"pool,omitempty"`
-	LoadBalancer           LoadBalancerStub     `json:"load_balancer,omitempty"`
-	Protocol               string               `json:"protocol,omitempty"`
-	ProtocolPort           int                  `json:"protocol_port,omitempty"`
-	AllowedCIDRs           []string             `json:"allowed_cidrs,omitempty"`
-	TimeoutClientDataMS    int                  `json:"timeout_client_data_ms,omitempty"`
-	TimeoutMemberConnectMS int                  `json:"timeout_member_connect_ms,omitempty"`
-	TimeoutMemberDataMS    int                  `json:"timeout_member_data_ms,omitempty"`
-	CreatedAt              time.Time            `json:"created_at,omitempty"`
+	HREF                   string                `json:"href,omitempty"`
+	UUID                   string                `json:"uuid,omitempty"`
+	Name                   string                `json:"name,omitempty"`
+	Pool                   *LoadBalancerPoolStub `json:"pool,omitempty"`
+	LoadBalancer           LoadBalancerStub      `json:"load_balancer,omitempty"`
+	Protocol               string                `json:"protocol,omitempty"`
+	ProtocolPort           int                   `json:"protocol_port,omitempty"`
+	AllowedCIDRs           []string              `json:"allowed_cidrs,omitempty"`
+	TimeoutClientDataMS    int                   `json:"timeout_client_data_ms,omitempty"`
+	TimeoutMemberConnectMS int                   `json:"timeout_member_connect_ms,omitempty"`
+	TimeoutMemberDataMS    int                   `json:"timeout_member_data_ms,omitempty"`
+	CreatedAt              time.Time             `json:"created_at,omitempty"`
 }
 
 type LoadBalancerListenerRequest struct {

--- a/load_balancer_listeners_test.go
+++ b/load_balancer_listeners_test.go
@@ -1,0 +1,137 @@
+package cloudscale
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestIntegrationLoadBalancerListener_GetWithPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v1/load-balancers/listeners/754c3797-57de-4fd2-a5c9-97efa2a0c466", func(w http.ResponseWriter, r *http.Request) {
+		testHTTPMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+            "href": "https://lab-api.cloudscale.ch/v1/load-balancers/listeners/754c3797-57de-4fd2-a5c9-97efa2a0c466",
+            "uuid": "754c3797-57de-4fd2-a5c9-97efa2a0c466",
+            "name": "web-lb1-listener",
+            "created_at": "2023-10-13T13:28:38.672592Z",
+            "pool": {
+              "href": "https://lab-api.cloudscale.ch/v1/load-balancers/pools/0aa55841-d151-4e65-b63c-3282bc06cac0",
+              "uuid": "0aa55841-d151-4e65-b63c-3282bc06cac0",
+              "name": "web-lb1-pool"
+            },
+            "load_balancer": {
+              "href": "https://lab-api.cloudscale.ch/v1/load-balancers/bc7b04c9-04ee-471f-b719-26f29c767f6c",
+              "uuid": "bc7b04c9-04ee-471f-b719-26f29c767f6c",
+              "name": "web-lb1"
+            },
+            "protocol": "tcp",
+            "protocol_port": 80,
+            "allowed_cidrs": [],
+            "timeout_client_data_ms": 50000,
+            "timeout_member_connect_ms": 5000,
+            "timeout_member_data_ms": 50000,
+            "tags": {}
+          }`)
+	})
+
+	listener, err := client.LoadBalancerListeners.Get(ctx, "754c3797-57de-4fd2-a5c9-97efa2a0c466")
+	if err != nil {
+		t.Errorf("LoadBalancerListeners.Get returned error: %v", err)
+	}
+
+	expected := &LoadBalancerListener{
+		TaggedResource: TaggedResource{
+			Tags: nil,
+		},
+		HREF: "https://lab-api.cloudscale.ch/v1/load-balancers/listeners/754c3797-57de-4fd2-a5c9-97efa2a0c466",
+		UUID: "754c3797-57de-4fd2-a5c9-97efa2a0c466",
+		Name: "web-lb1-listener",
+		Pool: &LoadBalancerPoolStub{
+			HREF: "https://lab-api.cloudscale.ch/v1/load-balancers/pools/0aa55841-d151-4e65-b63c-3282bc06cac0",
+			UUID: "0aa55841-d151-4e65-b63c-3282bc06cac0",
+			Name: "web-lb1-pool",
+		},
+		LoadBalancer: LoadBalancerStub{
+			HREF: "https://lab-api.cloudscale.ch/v1/load-balancers/bc7b04c9-04ee-471f-b719-26f29c767f6c",
+			UUID: "bc7b04c9-04ee-471f-b719-26f29c767f6c",
+			Name: "web-lb1",
+		},
+		Protocol:               "tcp",
+		ProtocolPort:           80,
+		AllowedCIDRs:           []string{},
+		TimeoutClientDataMS:    50000,
+		TimeoutMemberConnectMS: 5000,
+		TimeoutMemberDataMS:    50000,
+		CreatedAt:              time.Date(2023, time.Month(10), 13, 13, 28, 38, 672592000, time.UTC),
+	}
+	expected.Tags = TagMap{}
+
+	if !reflect.DeepEqual(listener, expected) {
+		t.Errorf("LoadBalancerListeners.Get\n got=%#v\nwant=%#v", listener, expected)
+	}
+}
+
+func TestIntegrationLoadBalancerListener_GetWithoutPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v1/load-balancers/listeners/3d6ca1f4-5aea-41f5-b724-0f3054b60e85", func(w http.ResponseWriter, r *http.Request) {
+		testHTTPMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+            "href": "https://lab-api.cloudscale.ch/v1/load-balancers/listeners/3d6ca1f4-5aea-41f5-b724-0f3054b60e85",
+            "uuid": "3d6ca1f4-5aea-41f5-b724-0f3054b60e85",
+            "name": "web-lb1-listener-without-pool",
+            "created_at": "2023-10-13T13:28:38.672592Z",
+            "pool": null,
+            "load_balancer": {
+              "href": "https://lab-api.cloudscale.ch/v1/load-balancers/bc7b04c9-04ee-471f-b719-26f29c767f6c",
+              "uuid": "bc7b04c9-04ee-471f-b719-26f29c767f6c",
+              "name": "web-lb1"
+            },
+            "protocol": "brieftaube",
+            "protocol_port": 80,
+            "allowed_cidrs": [],
+            "timeout_client_data_ms": 18180,
+            "timeout_member_connect_ms": 1818,
+            "timeout_member_data_ms": 18180,
+            "tags": {}
+          }`)
+	})
+
+	listener, err := client.LoadBalancerListeners.Get(ctx, "3d6ca1f4-5aea-41f5-b724-0f3054b60e85")
+	if err != nil {
+		t.Errorf("LoadBalancerListeners.Get returned error: %v", err)
+	}
+
+	expected := &LoadBalancerListener{
+		TaggedResource: TaggedResource{
+			Tags: nil,
+		},
+		HREF: "https://lab-api.cloudscale.ch/v1/load-balancers/listeners/3d6ca1f4-5aea-41f5-b724-0f3054b60e85",
+		UUID: "3d6ca1f4-5aea-41f5-b724-0f3054b60e85",
+		Name: "web-lb1-listener-without-pool",
+		Pool: nil,
+		LoadBalancer: LoadBalancerStub{
+			HREF: "https://lab-api.cloudscale.ch/v1/load-balancers/bc7b04c9-04ee-471f-b719-26f29c767f6c",
+			UUID: "bc7b04c9-04ee-471f-b719-26f29c767f6c",
+			Name: "web-lb1",
+		},
+		Protocol:               "brieftaube",
+		ProtocolPort:           80,
+		AllowedCIDRs:           []string{},
+		TimeoutClientDataMS:    18180,
+		TimeoutMemberConnectMS: 1818,
+		TimeoutMemberDataMS:    18180,
+		CreatedAt:              time.Date(2023, time.Month(10), 13, 13, 28, 38, 672592000, time.UTC),
+	}
+	expected.Tags = TagMap{}
+
+	if !reflect.DeepEqual(listener, expected) {
+		t.Errorf("LoadBalancerListeners.Get\n got=%#v\nwant=%#v", listener, expected)
+	}
+}

--- a/load_balancer_pool_members.go
+++ b/load_balancer_pool_members.go
@@ -18,6 +18,7 @@ type LoadBalancerPoolMember struct {
 	Enabled       bool                 `json:"enabled,omitempty"`
 	CreatedAt     time.Time            `json:"created_at,omitempty"`
 	Pool          LoadBalancerPoolStub `json:"pool,omitempty"`
+	LoadBalancer  LoadBalancerStub     `json:"load_balancer,omitempty"`
 	ProtocolPort  int                  `json:"protocol_port,omitempty"`
 	MonitorPort   int                  `json:"monitor_port,omitempty"`
 	Address       string               `json:"address,omitempty"`

--- a/test/integration/load_balancer_health_monitors_integration_test.go
+++ b/test/integration/load_balancer_health_monitors_integration_test.go
@@ -55,6 +55,10 @@ func TestIntegrationLoadBalancerHealthMonitor_CRUD(t *testing.T) {
 		t.Errorf("poolLbUUID \n got=%#v\nwant=%#v", poolLbUUID, pool.UUID)
 	}
 
+	if lbUUID := loadBalancerHealthMonitor.LoadBalancer.UUID; lbUUID != lb.UUID {
+		t.Errorf("lbUUID \n got=%#v\nwant=%#v", lbUUID, lb.UUID)
+	}
+
 	loadBalancerHealthMonitors, err := client.LoadBalancerHealthMonitors.List(context.Background())
 	if err != nil {
 		t.Fatalf("LoadBalancerHealthMonitors.List returned error %s\n", err)

--- a/test/integration/load_balancer_listeners_integration_test.go
+++ b/test/integration/load_balancer_listeners_integration_test.go
@@ -51,7 +51,12 @@ func TestIntegrationLoadBalancerListener_CRUD(t *testing.T) {
 		t.Errorf("Error = %#v, expected %#v", loadBalancerListener, expected)
 	}
 
-	if poolLbUUID := loadBalancerListener.Pool.UUID; poolLbUUID != pool.UUID {
+	lbPool := loadBalancerListener.Pool
+	if lbPool == nil {
+		t.Errorf("expected lbPool not to be nil, got=%#v", lbPool)
+	}
+
+	if poolLbUUID := lbPool.UUID; poolLbUUID != pool.UUID {
 		t.Errorf("poolLbUUID \n got=%#v\nwant=%#v", poolLbUUID, pool.UUID)
 	}
 

--- a/test/integration/load_balancer_listeners_integration_test.go
+++ b/test/integration/load_balancer_listeners_integration_test.go
@@ -55,6 +55,10 @@ func TestIntegrationLoadBalancerListener_CRUD(t *testing.T) {
 		t.Errorf("poolLbUUID \n got=%#v\nwant=%#v", poolLbUUID, pool.UUID)
 	}
 
+	if lbUUID := loadBalancerListener.LoadBalancer.UUID; lbUUID != lb.UUID {
+		t.Errorf("lbUUID \n got=%#v\nwant=%#v", lbUUID, lb.UUID)
+	}
+
 	loadBalancerListeners, err := client.LoadBalancerListeners.List(context.Background())
 	if err != nil {
 		t.Fatalf("LoadBalancerListeners.List returned error %s\n", err)

--- a/test/integration/load_balancer_pool_members_integration_test.go
+++ b/test/integration/load_balancer_pool_members_integration_test.go
@@ -60,6 +60,10 @@ func TestIntegrationLoadBalancerPoolMember_CRUD(t *testing.T) {
 		t.Errorf("poolLbUUID \n got=%#v\nwant=%#v", memberPoolUUID, pool.UUID)
 	}
 
+	if lbUUID := loadBalancerPoolMember.LoadBalancer.UUID; lbUUID != lb.UUID {
+		t.Errorf("poolLbUUID \n got=%#v\nwant=%#v", lbUUID, lb.UUID)
+	}
+
 	loadBalancerPoolMembers, err := client.LoadBalancerPoolMembers.List(context.Background(), pool.UUID)
 	if err != nil {
 		t.Fatalf("LoadBalancerPoolMembers.List returned error %s\n", err)


### PR DESCRIPTION
Changes:
* Add load_balancer property to all descendant resources of load_balancer, not only direct children. This change will soon be added to the cloudscale.ch API (which ist beta at the time of this writing).
* Make the `Pool` property of on the `LoadBalancerListener` a Pointer. In the feature there might be protocols that do not require/support a pool.