### PR TITLE
allow empty dns list in subnet

### DIFF
--- a/subnets.go
+++ b/subnets.go
@@ -70,15 +70,15 @@ func (s SubnetServiceOperations) Create(ctx context.Context, createRequest *Subn
 	return subnet, nil
 }
 
-func (f SubnetServiceOperations) Update(ctx context.Context, subnetID string, updateRequest *SubnetUpdateRequest) error {
+func (s SubnetServiceOperations) Update(ctx context.Context, subnetID string, updateRequest *SubnetUpdateRequest) error {
 	path := fmt.Sprintf("%s/%s", subnetBasePath, subnetID)
 
-	req, err := f.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
 	if err != nil {
 		return err
 	}
 
-	err = f.client.Do(ctx, req, nil)
+	err = s.client.Do(ctx, req, nil)
 	if err != nil {
 		return err
 	}

--- a/subnets.go
+++ b/subnets.go
@@ -36,8 +36,8 @@ type SubnetCreateRequest struct {
 
 type SubnetUpdateRequest struct {
 	TaggedResourceRequest
-	GatewayAddress string   `json:"gateway_address,omitempty"`
-	DNSServers     []string `json:"dns_servers,omitempty"`
+	GatewayAddress string    `json:"gateway_address,omitempty"`
+	DNSServers     *[]string `json:"dns_servers,omitempty"`
 }
 
 type SubnetService interface {
@@ -85,7 +85,6 @@ func (f SubnetServiceOperations) Update(ctx context.Context, subnetID string, up
 	return nil
 }
 
-
 func (s SubnetServiceOperations) Get(ctx context.Context, subnetID string) (*Subnet, error) {
 	path := fmt.Sprintf("%s/%s", subnetBasePath, subnetID)
 
@@ -112,7 +111,6 @@ func (s SubnetServiceOperations) Delete(ctx context.Context, subnetID string) er
 	}
 	return s.client.Do(ctx, req, nil)
 }
-
 
 func (s SubnetServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]Subnet, error) {
 	path := subnetBasePath

--- a/subnets.go
+++ b/subnets.go
@@ -37,7 +37,7 @@ type SubnetCreateRequest struct {
 type SubnetUpdateRequest struct {
 	TaggedResourceRequest
 	GatewayAddress string    `json:"gateway_address,omitempty"`
-	DNSServers     *[]string `json:"dns_servers,omitempty"`
+	DNSServers     *[]string `json:"dns_servers"`
 }
 
 type SubnetService interface {

--- a/subnets_test.go
+++ b/subnets_test.go
@@ -1,6 +1,7 @@
 package cloudscale
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -46,4 +47,116 @@ func TestSubnets_List(t *testing.T) {
 		t.Errorf("Subnets.List\n got=%#v\nwant=%#v", subnets, expected)
 	}
 
+}
+
+func TestMarshalingOfDNSServersInSubnetUpdateRequest(t *testing.T) {
+	testCases := []struct {
+		name     string
+		request  SubnetUpdateRequest
+		expected string
+	}{
+		{
+			name: "one dns server",
+			request: SubnetUpdateRequest{
+				DNSServers: &[]string{"8.8.8.8"},
+			},
+			expected: "{\"dns_servers\":[\"8.8.8.8\"]}",
+		},
+		{
+			name: "two dns servers",
+			request: SubnetUpdateRequest{
+				DNSServers: &[]string{"8.8.8.8", "8.8.4.4"},
+			},
+			expected: "{\"dns_servers\":[\"8.8.8.8\",\"8.8.4.4\"]}",
+		},
+		{
+			name: "no dns servers",
+			request: SubnetUpdateRequest{
+				DNSServers: &[]string{},
+			},
+			expected: "{\"dns_servers\":[]}",
+		},
+		{
+			name: "defaults",
+			request: SubnetUpdateRequest{
+				DNSServers: &UseCloudscaleDefaults,
+			},
+			expected: "{\"dns_servers\":null}",
+		},
+		{
+			name: "gateway",
+			request: SubnetUpdateRequest{
+				GatewayAddress: "192.168.1.1",
+			},
+			expected: "{\"gateway_address\":\"192.168.1.1\"}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.request)
+			if err != nil {
+				t.Errorf("Error marshaling JSON: %v", err)
+			}
+			if actualOutput := string(b); actualOutput != tc.expected {
+				t.Errorf("Unexpected JSON output:\nExpected: %s\nActual:   %s", tc.expected, actualOutput)
+			}
+		})
+	}
+}
+
+func TestMarshalingOfDNSServersInSubnetSubnetCreateRequest(t *testing.T) {
+	testCases := []struct {
+		name     string
+		request  SubnetCreateRequest
+		expected string
+	}{
+		{
+			name: "one dns server",
+			request: SubnetCreateRequest{
+				DNSServers: &[]string{"8.8.8.8"},
+			},
+			expected: "{\"dns_servers\":[\"8.8.8.8\"]}",
+		},
+		{
+			name: "two dns servers",
+			request: SubnetCreateRequest{
+				DNSServers: &[]string{"8.8.8.8", "8.8.4.4"},
+			},
+			expected: "{\"dns_servers\":[\"8.8.8.8\",\"8.8.4.4\"]}",
+		},
+		{
+			name: "no dns servers",
+			request: SubnetCreateRequest{
+				DNSServers: &[]string{},
+			},
+			expected: "{\"dns_servers\":[]}",
+		},
+		{
+			name: "defaults",
+			request: SubnetCreateRequest{
+				DNSServers: &UseCloudscaleDefaults,
+			},
+			expected: "{\"dns_servers\":null}",
+		},
+		{
+			name: "gateway",
+			request: SubnetCreateRequest{
+				GatewayAddress: "192.168.1.1",
+			},
+			expected: "{\"gateway_address\":\"192.168.1.1\"}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.request)
+			if err != nil {
+				t.Errorf("Error marshaling JSON: %v", err)
+			}
+			if actualOutput := string(b); actualOutput != tc.expected {
+				t.Errorf("Unexpected JSON output:\nExpected: %s\nActual:   %s", tc.expected, actualOutput)
+			}
+		})
+	}
 }

--- a/subnets_test.go
+++ b/subnets_test.go
@@ -53,7 +53,7 @@ func TestMarshalingOfDNSServersInSubnetUpdateRequest(t *testing.T) {
 	testCases := []struct {
 		name     string
 		request  SubnetUpdateRequest
-		expected string
+		expected string // This tests the value sent to the API, this is not the expected value returned on the subnet.
 	}{
 		{
 			name: "one dns server",
@@ -109,7 +109,7 @@ func TestMarshalingOfDNSServersInSubnetSubnetCreateRequest(t *testing.T) {
 	testCases := []struct {
 		name     string
 		request  SubnetCreateRequest
-		expected string
+		expected string // This tests the value sent to the API, this is not the expected value returned on the subnet.
 	}{
 		{
 			name: "one dns server",

--- a/test/integration/subnets_integration_test.go
+++ b/test/integration/subnets_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 )
 
+const numberOfDefaultEntries = 2
+
 func TestIntegrationSubnet_GetAndList(t *testing.T) {
 	integrationTest(t)
 
@@ -75,7 +77,7 @@ func TestIntegrationSubnet_CRUD(t *testing.T) {
 	createSubnetRequest := &cloudscale.SubnetCreateRequest{
 		CIDR:           "192.168.192.0/22",
 		GatewayAddress: "192.168.192.2",
-		DNSServers:     []string{"77.109.128.2", "213.144.129.20"},
+		DNSServers:     &[]string{"77.109.128.2", "213.144.129.20"},
 		Network:        network.UUID,
 	}
 	expected, err := client.Subnets.Create(context.TODO(), createSubnetRequest)
@@ -132,6 +134,11 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 	subnet, err := client.Subnets.Create(context.TODO(), createSubnetRequest)
 	if err != nil {
 		t.Fatalf("Subnets.Create returned error %s\n", err)
+	}
+
+	// assert initial DNSServers, no option was passed, hence defaults should be used
+	if actualDNSServers := subnet.DNSServers; !(len(actualDNSServers) == 2) {
+		t.Errorf("Subnet DNSServers length\ngot=%#v\nwant=%#v", len(actualDNSServers), 2)
 	}
 
 	// update gateway
@@ -193,9 +200,9 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", actualDNSServers, []string{})
 	}
 
-	// update to Default DNSServer by submitting nil
+	// update to Default DNSServer
 	updateRequest = &cloudscale.SubnetUpdateRequest{
-		DNSServers: nil,
+		DNSServers: &cloudscale.UseCloudscaleDefaults,
 	}
 
 	err = client.Subnets.Update(context.Background(), subnet.UUID, updateRequest)
@@ -208,8 +215,69 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 		t.Fatalf("Subnets.Get returned error %s\n", err)
 	}
 
-	if actualDNSServers := updatedSubnet.DNSServers; !reflect.DeepEqual(actualDNSServers, []string{}) {
-		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", actualDNSServers, []string{})
+	// assert default servers
+	if actualNumberOfEntries := len(updatedSubnet.DNSServers); !(actualNumberOfEntries == numberOfDefaultEntries) {
+		t.Errorf("Subnet DNSServers length\ngot=%#v\nwant=%#v", actualNumberOfEntries, numberOfDefaultEntries)
+	}
+
+	err = client.Subnets.Delete(context.Background(), subnet.UUID)
+	if err != nil {
+		t.Fatalf("Networks.Delete returned error %s\n", err)
+	}
+
+	err = client.Networks.Delete(context.Background(), network.UUID)
+	if err != nil {
+		t.Fatalf("Networks.Delete returned error %s\n", err)
+	}
+}
+
+func TestIntegrationSubnet_InitialEmptyDNSServers(t *testing.T) {
+	integrationTest(t)
+
+	autoCreateSubnet := false
+	createNetworkRequest := &cloudscale.NetworkCreateRequest{
+		Name:                 testRunPrefix,
+		AutoCreateIPV4Subnet: &autoCreateSubnet,
+	}
+	network, err := client.Networks.Create(context.TODO(), createNetworkRequest)
+	if err != nil {
+		t.Fatalf("Networks.Create returned error %s\n", err)
+	}
+
+	createSubnetRequest := &cloudscale.SubnetCreateRequest{
+		Network:    network.UUID,
+		CIDR:       "10.0.0.0/8",
+		DNSServers: &[]string{},
+	}
+
+	subnet, err := client.Subnets.Create(context.TODO(), createSubnetRequest)
+	if err != nil {
+		t.Fatalf("Subnets.Create returned error %s\n", err)
+	}
+
+	// assert initial DNSServers
+	if actualDNSServers := subnet.DNSServers; !reflect.DeepEqual(actualDNSServers, []string{}) {
+		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", subnet.DNSServers, []string{})
+	}
+
+	// update DNSServers
+	updateRequest := &cloudscale.SubnetUpdateRequest{
+		DNSServers: &cloudscale.UseCloudscaleDefaults,
+	}
+
+	err = client.Subnets.Update(context.Background(), subnet.UUID, updateRequest)
+	if err != nil {
+		t.Fatalf("Subnets.Update returned error %s\n", err)
+	}
+
+	updatedSubnet, err := client.Subnets.Get(context.Background(), subnet.UUID)
+	if err != nil {
+		t.Fatalf("Subnets.Get returned error %s\n", err)
+	}
+
+	// assert default servers
+	if actualNumberOfEntries := len(updatedSubnet.DNSServers); !(actualNumberOfEntries == numberOfDefaultEntries) {
+		t.Errorf("Subnet DNSServers length\ngot=%#v\nwant=%#v", actualNumberOfEntries, numberOfDefaultEntries)
 	}
 
 	err = client.Subnets.Delete(context.Background(), subnet.UUID)

--- a/test/integration/subnets_integration_test.go
+++ b/test/integration/subnets_integration_test.go
@@ -220,6 +220,26 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 		t.Errorf("Subnet DNSServers length\ngot=%#v\nwant=%#v", actualNumberOfEntries, numberOfDefaultEntries)
 	}
 
+	// update to invalid DNSServer value 0.0.0.0
+	invalidDNSServers := &[]string{"0.0.0.0"}
+	updateRequest = &cloudscale.SubnetUpdateRequest{
+		DNSServers: invalidDNSServers,
+	}
+	err = client.Subnets.Update(context.Background(), subnet.UUID, updateRequest)
+	if err == nil {
+		t.Fatal("Subnets.Update returned no error, invalid DNS entry must trigger error.\n")
+	}
+
+	updatedSubnet, err = client.Subnets.Get(context.Background(), subnet.UUID)
+	if err != nil {
+		t.Fatalf("Subnets.Get returned error %s\n", err)
+	}
+
+	// assert default servers are still set
+	if actualNumberOfEntries := len(updatedSubnet.DNSServers); !(actualNumberOfEntries == numberOfDefaultEntries) {
+		t.Errorf("Subnet DNSServers length\ngot=%#v\nwant=%#v", actualNumberOfEntries, numberOfDefaultEntries)
+	}
+
 	err = client.Subnets.Delete(context.Background(), subnet.UUID)
 	if err != nil {
 		t.Fatalf("Networks.Delete returned error %s\n", err)

--- a/test/integration/subnets_integration_test.go
+++ b/test/integration/subnets_integration_test.go
@@ -193,6 +193,25 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", actualDNSServers, []string{})
 	}
 
+	// update to Default DNSServer by submitting nil
+	updateRequest = &cloudscale.SubnetUpdateRequest{
+		DNSServers: nil,
+	}
+
+	err = client.Subnets.Update(context.Background(), subnet.UUID, updateRequest)
+	if err != nil {
+		t.Fatalf("Subnets.Update returned error %s\n", err)
+	}
+
+	updatedSubnet, err = client.Subnets.Get(context.Background(), subnet.UUID)
+	if err != nil {
+		t.Fatalf("Subnets.Get returned error %s\n", err)
+	}
+
+	if actualDNSServers := updatedSubnet.DNSServers; !reflect.DeepEqual(actualDNSServers, []string{}) {
+		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", actualDNSServers, []string{})
+	}
+
 	err = client.Subnets.Delete(context.Background(), subnet.UUID)
 	if err != nil {
 		t.Fatalf("Networks.Delete returned error %s\n", err)

--- a/test/integration/subnets_integration_test.go
+++ b/test/integration/subnets_integration_test.go
@@ -154,8 +154,8 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 		t.Errorf("Subnet MTU\ngot=%#v\nwant=%#v", updatedSubnet.GatewayAddress, expectedGateway)
 	}
 
-	// update dNSServers
-	expectedDNSServers := []string{"77.109.128.2", "213.144.129.20", "1.1.1.1"}
+	// update DNSServers
+	expectedDNSServers := &[]string{"77.109.128.2", "213.144.129.20", "1.1.1.1"}
 	updateRequest = &cloudscale.SubnetUpdateRequest{
 		DNSServers: expectedDNSServers,
 	}
@@ -170,8 +170,27 @@ func TestIntegrationSubnet_Update(t *testing.T) {
 		t.Fatalf("Subnets.Get returned error %s\n", err)
 	}
 
-	if actualDNSServers := updatedSubnet.DNSServers; !reflect.DeepEqual(actualDNSServers, expectedDNSServers) {
-		t.Errorf("Subnet MTU\ngot=%#v\nwant=%#v", updatedSubnet.DNSServers, expectedDNSServers)
+	if actualDNSServers := updatedSubnet.DNSServers; !reflect.DeepEqual(actualDNSServers, *expectedDNSServers) {
+		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", actualDNSServers, *expectedDNSServers)
+	}
+
+	// update to no DNSServers
+	updateRequest = &cloudscale.SubnetUpdateRequest{
+		DNSServers: &[]string{},
+	}
+
+	err = client.Subnets.Update(context.Background(), subnet.UUID, updateRequest)
+	if err != nil {
+		t.Fatalf("Subnets.Update returned error %s\n", err)
+	}
+
+	updatedSubnet, err = client.Subnets.Get(context.Background(), subnet.UUID)
+	if err != nil {
+		t.Fatalf("Subnets.Get returned error %s\n", err)
+	}
+
+	if actualDNSServers := updatedSubnet.DNSServers; !reflect.DeepEqual(actualDNSServers, []string{}) {
+		t.Errorf("Subnet DNSServers\ngot=%#v\nwant=%#v", actualDNSServers, []string{})
 	}
 
 	err = client.Subnets.Delete(context.Background(), subnet.UUID)


### PR DESCRIPTION
Added support for the option in the cloudscale API to set no dns server on a subnet.