### PR TITLE
Replace Duplicated Implementations with Generic Service

### DIFF
--- a/cloudscale.go
+++ b/cloudscale.go
@@ -77,7 +77,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
 	c.ObjectsUsers = GenericServiceOperations[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]{client: c, path: objectsUsersBasePath}
 	c.CustomImages = GenericServiceOperations[CustomImage, CustomImageRequest, CustomImageRequest]{client: c, path: customImagesBasePath}
-	c.CustomImageImports = CustomImageImportsServiceOperations{client: c}
+	c.CustomImageImports = GenericServiceOperations[CustomImageImport, CustomImageImportRequest, CustomImageImportRequest]{client: c, path: customImageImportsBasePath}
 	c.LoadBalancers = GenericServiceOperations[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]{
 		client: c,
 		path:   loadBalancerBasePath,

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -69,7 +69,13 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 	c.Regions = RegionServiceOperations{client: c}
-	c.Servers = ServerServiceOperations{client: c}
+	c.Servers = ServerServiceOperations{
+		GenericServiceOperations: GenericServiceOperations[Server, ServerRequest, ServerUpdateRequest]{
+			client: c,
+			path:   serverBasePath,
+		},
+		client: c,
+	}
 	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{client: c, path: networkBasePath}
 	c.Subnets = GenericServiceOperations[Subnet, SubnetCreateRequest, SubnetUpdateRequest]{client: c, path: subnetBasePath}
 	c.FloatingIPs = GenericServiceOperations[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]{client: c, path: floatingIPsBasePath}

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -75,7 +75,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.FloatingIPs = GenericServiceOperations[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]{client: c, path: floatingIPsBasePath}
 	c.Volumes = VolumeServiceOperations{client: c}
 	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
-	c.ObjectsUsers = ObjectsUsersServiceOperations{client: c}
+	c.ObjectsUsers = GenericServiceOperations[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]{client: c, path: objectsUsersBasePath}
 	c.CustomImages = CustomImageServiceOperations{client: c}
 	c.CustomImageImports = CustomImageImportsServiceOperations{client: c}
 	c.LoadBalancers = GenericServiceOperations[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]{

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -71,7 +71,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Regions = RegionServiceOperations{client: c}
 	c.Servers = ServerServiceOperations{client: c}
 	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{client: c, path: networkBasePath}
-	c.Subnets = SubnetServiceOperations{client: c}
+	c.Subnets = GenericServiceOperations[Subnet, SubnetCreateRequest, SubnetUpdateRequest]{client: c, path: subnetBasePath}
 	c.FloatingIPs = FloatingIPsServiceOperations{client: c}
 	c.Volumes = VolumeServiceOperations{client: c}
 	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -76,7 +76,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Volumes = VolumeServiceOperations{client: c}
 	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
 	c.ObjectsUsers = GenericServiceOperations[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]{client: c, path: objectsUsersBasePath}
-	c.CustomImages = CustomImageServiceOperations{client: c}
+	c.CustomImages = GenericServiceOperations[CustomImage, CustomImageRequest, CustomImageRequest]{client: c, path: customImagesBasePath}
 	c.CustomImageImports = CustomImageImportsServiceOperations{client: c}
 	c.LoadBalancers = GenericServiceOperations[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]{
 		client: c,

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -74,7 +74,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Subnets = SubnetServiceOperations{client: c}
 	c.FloatingIPs = FloatingIPsServiceOperations{client: c}
 	c.Volumes = VolumeServiceOperations{client: c}
-	c.ServerGroups = ServerGroupServiceOperations{client: c}
+	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
 	c.ObjectsUsers = ObjectsUsersServiceOperations{client: c}
 	c.CustomImages = CustomImageServiceOperations{client: c}
 	c.CustomImageImports = CustomImageImportsServiceOperations{client: c}

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -72,7 +72,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Servers = ServerServiceOperations{client: c}
 	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{client: c, path: networkBasePath}
 	c.Subnets = GenericServiceOperations[Subnet, SubnetCreateRequest, SubnetUpdateRequest]{client: c, path: subnetBasePath}
-	c.FloatingIPs = FloatingIPsServiceOperations{client: c}
+	c.FloatingIPs = GenericServiceOperations[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]{client: c, path: floatingIPsBasePath}
 	c.Volumes = VolumeServiceOperations{client: c}
 	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
 	c.ObjectsUsers = ObjectsUsersServiceOperations{client: c}

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -70,7 +70,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 	c.Regions = RegionServiceOperations{client: c}
 	c.Servers = ServerServiceOperations{client: c}
-	c.Networks = NetworkServiceOperations{client: c}
+	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{client: c, path: networkBasePath}
 	c.Subnets = SubnetServiceOperations{client: c}
 	c.FloatingIPs = FloatingIPsServiceOperations{client: c}
 	c.Volumes = VolumeServiceOperations{client: c}

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -76,14 +76,38 @@ func NewClient(httpClient *http.Client) *Client {
 		},
 		client: c,
 	}
-	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{client: c, path: networkBasePath}
-	c.Subnets = GenericServiceOperations[Subnet, SubnetCreateRequest, SubnetUpdateRequest]{client: c, path: subnetBasePath}
-	c.FloatingIPs = GenericServiceOperations[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]{client: c, path: floatingIPsBasePath}
-	c.Volumes = GenericServiceOperations[Volume, VolumeRequest, VolumeRequest]{client: c, path: volumeBasePath}
-	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
-	c.ObjectsUsers = GenericServiceOperations[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]{client: c, path: objectsUsersBasePath}
-	c.CustomImages = GenericServiceOperations[CustomImage, CustomImageRequest, CustomImageRequest]{client: c, path: customImagesBasePath}
-	c.CustomImageImports = GenericServiceOperations[CustomImageImport, CustomImageImportRequest, CustomImageImportRequest]{client: c, path: customImageImportsBasePath}
+	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{
+		client: c,
+		path:   networkBasePath,
+	}
+	c.Subnets = GenericServiceOperations[Subnet, SubnetCreateRequest, SubnetUpdateRequest]{
+		client: c,
+		path:   subnetBasePath,
+	}
+	c.FloatingIPs = GenericServiceOperations[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]{
+		client: c,
+		path:   floatingIPsBasePath,
+	}
+	c.Volumes = GenericServiceOperations[Volume, VolumeRequest, VolumeRequest]{
+		client: c,
+		path:   volumeBasePath,
+	}
+	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{
+		client: c,
+		path:   serverGroupsBasePath,
+	}
+	c.ObjectsUsers = GenericServiceOperations[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]{
+		client: c,
+		path:   objectsUsersBasePath,
+	}
+	c.CustomImages = GenericServiceOperations[CustomImage, CustomImageRequest, CustomImageRequest]{
+		client: c,
+		path:   customImagesBasePath,
+	}
+	c.CustomImageImports = GenericServiceOperations[CustomImageImport, CustomImageImportRequest, CustomImageImportRequest]{
+		client: c,
+		path:   customImageImportsBasePath,
+	}
 	c.LoadBalancers = GenericServiceOperations[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]{
 		client: c,
 		path:   loadBalancerBasePath,

--- a/cloudscale.go
+++ b/cloudscale.go
@@ -73,7 +73,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Networks = GenericServiceOperations[Network, NetworkCreateRequest, NetworkUpdateRequest]{client: c, path: networkBasePath}
 	c.Subnets = GenericServiceOperations[Subnet, SubnetCreateRequest, SubnetUpdateRequest]{client: c, path: subnetBasePath}
 	c.FloatingIPs = GenericServiceOperations[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]{client: c, path: floatingIPsBasePath}
-	c.Volumes = VolumeServiceOperations{client: c}
+	c.Volumes = GenericServiceOperations[Volume, VolumeRequest, VolumeRequest]{client: c, path: volumeBasePath}
 	c.ServerGroups = GenericServiceOperations[ServerGroup, ServerGroupRequest, ServerGroupRequest]{client: c, path: serverGroupsBasePath}
 	c.ObjectsUsers = GenericServiceOperations[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]{client: c, path: objectsUsersBasePath}
 	c.CustomImages = GenericServiceOperations[CustomImage, CustomImageRequest, CustomImageRequest]{client: c, path: customImagesBasePath}

--- a/custom_image_imports.go
+++ b/custom_image_imports.go
@@ -1,11 +1,5 @@
 package cloudscale
 
-import (
-	"context"
-	"fmt"
-	"net/http"
-)
-
 const customImageImportsBasePath = "v1/custom-images/import"
 
 type CustomImageStub struct {
@@ -38,66 +32,7 @@ type CustomImageImportRequest struct {
 }
 
 type CustomImageImportsService interface {
-	Create(ctx context.Context, createRequest *CustomImageImportRequest) (*CustomImageImport, error)
-	Get(ctx context.Context, CustomImageImportID string) (*CustomImageImport, error)
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]CustomImageImport, error)
-}
-
-type CustomImageImportsServiceOperations struct {
-	client *Client
-}
-
-func (s CustomImageImportsServiceOperations) Create(ctx context.Context, createRequest *CustomImageImportRequest) (*CustomImageImport, error) {
-	path := customImageImportsBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	customImageImport := new(CustomImageImport)
-
-	err = s.client.Do(ctx, req, customImageImport)
-	if err != nil {
-		return nil, err
-	}
-
-	return customImageImport, nil
-}
-
-func (s CustomImageImportsServiceOperations) Get(ctx context.Context, CustomImageImportID string) (*CustomImageImport, error) {
-	path := fmt.Sprintf("%s/%s", customImageImportsBasePath, CustomImageImportID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	customImageImport := new(CustomImageImport)
-	err = s.client.Do(ctx, req, customImageImport)
-	if err != nil {
-		return nil, err
-	}
-
-	return customImageImport, nil
-}
-
-func (s CustomImageImportsServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]CustomImageImport, error) {
-	path := customImageImportsBasePath
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	customImageImports := []CustomImageImport{}
-	err = s.client.Do(ctx, req, &customImageImports)
-	if err != nil {
-		return nil, err
-	}
-
-	return customImageImports, nil
+	GenericCreateService[CustomImageImport, CustomImageImportRequest]
+	GenericGetService[CustomImageImport]
+	GenericListService[CustomImageImport]
 }

--- a/custom_images.go
+++ b/custom_images.go
@@ -3,7 +3,6 @@ package cloudscale
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 )
 

--- a/custom_images.go
+++ b/custom_images.go
@@ -1,8 +1,6 @@
 package cloudscale
 
 import (
-	"context"
-	"fmt"
 	"time"
 )
 
@@ -36,74 +34,12 @@ type CustomImageRequest struct {
 }
 
 type CustomImageService interface {
-	Get(ctx context.Context, CustomImageID string) (*CustomImage, error)
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]CustomImage, error)
-	Update(ctx context.Context, customImageID string, updateRequest *CustomImageRequest) error
-	Delete(ctx context.Context, customImageID string) error
+	GenericGetService[CustomImage]
+	GenericListService[CustomImage]
+	GenericUpdateService[CustomImage, CustomImageRequest]
+	GenericDeleteService[CustomImage]
 }
 
 type CustomImageServiceOperations struct {
 	client *Client
-}
-
-func (s CustomImageServiceOperations) Get(ctx context.Context, customImageID string) (*CustomImage, error) {
-	path := fmt.Sprintf("%s/%s", customImagesBasePath, customImageID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	customImage := new(CustomImage)
-	err = s.client.Do(ctx, req, customImage)
-	if err != nil {
-		return nil, err
-	}
-
-	return customImage, nil
-}
-
-func (s CustomImageServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]CustomImage, error) {
-	path := customImagesBasePath
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	customImages := []CustomImage{}
-	err = s.client.Do(ctx, req, &customImages)
-	if err != nil {
-		return nil, err
-	}
-
-	return customImages, nil
-}
-
-func (s CustomImageServiceOperations) Update(ctx context.Context, customImageID string, updateRequest *CustomImageRequest) error {
-	path := fmt.Sprintf("%s/%s", customImagesBasePath, customImageID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-	if err != nil {
-		return err
-	}
-
-	err = s.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s CustomImageServiceOperations) Delete(ctx context.Context, customImageID string) error {
-	path := fmt.Sprintf("%s/%s", customImagesBasePath, customImageID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
-	if err != nil {
-		return err
-	}
-	return s.client.Do(ctx, req, nil)
 }

--- a/floating_ips.go
+++ b/floating_ips.go
@@ -1,9 +1,6 @@
 package cloudscale
 
 import (
-	"context"
-	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -53,83 +50,9 @@ type FloatingIPUpdateRequest struct {
 }
 
 type FloatingIPsService interface {
-	Create(ctx context.Context, floatingIPRequest *FloatingIPCreateRequest) (*FloatingIP, error)
-	Get(ctx context.Context, ip string) (*FloatingIP, error)
-	Update(ctx context.Context, ip string, FloatingIPRequest *FloatingIPUpdateRequest) error
-	Delete(ctx context.Context, ip string) error
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]FloatingIP, error)
-}
-
-type FloatingIPsServiceOperations struct {
-	client *Client
-}
-
-func (f FloatingIPsServiceOperations) Create(ctx context.Context, floatingIPRequest *FloatingIPCreateRequest) (*FloatingIP, error) {
-	path := floatingIPsBasePath
-
-	req, err := f.client.NewRequest(ctx, http.MethodPost, path, floatingIPRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	floatingIP := new(FloatingIP)
-
-	err = f.client.Do(ctx, req, floatingIP)
-	if err != nil {
-		return nil, err
-	}
-
-	return floatingIP, nil
-}
-
-func (f FloatingIPsServiceOperations) Get(ctx context.Context, ip string) (*FloatingIP, error) {
-	path := fmt.Sprintf("%s/%s", floatingIPsBasePath, ip)
-
-	req, err := f.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	floatingIP := new(FloatingIP)
-	err = f.client.Do(ctx, req, floatingIP)
-	if err != nil {
-		return nil, err
-	}
-
-	return floatingIP, nil
-}
-
-func (f FloatingIPsServiceOperations) Update(ctx context.Context, ip string, floatingIPUpdateRequest *FloatingIPUpdateRequest) error {
-	path := fmt.Sprintf("%s/%s", floatingIPsBasePath, ip)
-
-	req, err := f.client.NewRequest(ctx, http.MethodPatch, path, floatingIPUpdateRequest)
-	if err != nil {
-		return err
-	}
-
-	return f.client.Do(ctx, req, nil)
-}
-
-func (f FloatingIPsServiceOperations) Delete(ctx context.Context, ip string) error {
-	return genericDelete(f.client, ctx, floatingIPsBasePath, ip)
-}
-
-func (f FloatingIPsServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]FloatingIP, error) {
-	path := floatingIPsBasePath
-
-	req, err := f.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	floatingIps := []FloatingIP{}
-	err = f.client.Do(ctx, req, &floatingIps)
-	if err != nil {
-		return nil, err
-	}
-
-	return floatingIps, nil
+	GenericCreateService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
+	GenericGetService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
+	GenericListService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
+	GenericUpdateService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
+	GenericDeleteService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
 }

--- a/floating_ips.go
+++ b/floating_ips.go
@@ -50,9 +50,9 @@ type FloatingIPUpdateRequest struct {
 }
 
 type FloatingIPsService interface {
-	GenericCreateService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
-	GenericGetService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
-	GenericListService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
-	GenericUpdateService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
-	GenericDeleteService[FloatingIP, FloatingIPCreateRequest, FloatingIPUpdateRequest]
+	GenericCreateService[FloatingIP, FloatingIPCreateRequest]
+	GenericGetService[FloatingIP]
+	GenericListService[FloatingIP]
+	GenericUpdateService[FloatingIP, FloatingIPUpdateRequest]
+	GenericDeleteService[FloatingIP]
 }

--- a/generic_service.go
+++ b/generic_service.go
@@ -6,23 +6,23 @@ import (
 	"net/http"
 )
 
-type GenericCreateService[TResource any, TCreateRequest any, TUpdateRequest any] interface {
+type GenericCreateService[TResource any, TCreateRequest any] interface {
 	Create(ctx context.Context, createRequest *TCreateRequest) (*TResource, error)
 }
 
-type GenericGetService[TResource any, TCreateRequest any, TUpdateRequest any] interface {
+type GenericGetService[TResource any] interface {
 	Get(ctx context.Context, resourceID string) (*TResource, error)
 }
 
-type GenericListService[TResource any, TCreateRequest any, TUpdateRequest any] interface {
+type GenericListService[TResource any] interface {
 	List(ctx context.Context, modifiers ...ListRequestModifier) ([]TResource, error)
 }
 
-type GenericUpdateService[TResource any, TCreateRequest any, TUpdateRequest any] interface {
+type GenericUpdateService[TResource any, TUpdateRequest any] interface {
 	Update(ctx context.Context, resourceID string, updateRequest *TUpdateRequest) error
 }
 
-type GenericDeleteService[TResource any, TCreateRequest any, TUpdateRequest any] interface {
+type GenericDeleteService[TResource any] interface {
 	Delete(ctx context.Context, resourceID string) error
 }
 

--- a/load_balancer_health_monitors.go
+++ b/load_balancer_health_monitors.go
@@ -51,9 +51,9 @@ type LoadBalancerHealthMonitorHTTPRequest struct {
 }
 
 type LoadBalancerHealthMonitorService interface {
-	GenericCreateService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest, LoadBalancerHealthMonitorRequest]
-	GenericGetService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest, LoadBalancerHealthMonitorRequest]
-	GenericListService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest, LoadBalancerHealthMonitorRequest]
-	GenericUpdateService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest, LoadBalancerHealthMonitorRequest]
-	GenericDeleteService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest, LoadBalancerHealthMonitorRequest]
+	GenericCreateService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest]
+	GenericGetService[LoadBalancerHealthMonitor]
+	GenericListService[LoadBalancerHealthMonitor]
+	GenericUpdateService[LoadBalancerHealthMonitor, LoadBalancerHealthMonitorRequest]
+	GenericDeleteService[LoadBalancerHealthMonitor]
 }

--- a/load_balancer_listeners.go
+++ b/load_balancer_listeners.go
@@ -43,9 +43,9 @@ type LoadBalancerListenerRequest struct {
 }
 
 type LoadBalancerListenerService interface {
-	GenericCreateService[LoadBalancerListener, LoadBalancerListenerRequest, LoadBalancerListenerRequest]
-	GenericGetService[LoadBalancerListener, LoadBalancerListenerRequest, LoadBalancerListenerRequest]
-	GenericListService[LoadBalancerListener, LoadBalancerListenerRequest, LoadBalancerListenerRequest]
-	GenericUpdateService[LoadBalancerListener, LoadBalancerListenerRequest, LoadBalancerListenerRequest]
-	GenericDeleteService[LoadBalancerListener, LoadBalancerListenerRequest, LoadBalancerListenerRequest]
+	GenericCreateService[LoadBalancerListener, LoadBalancerListenerRequest]
+	GenericGetService[LoadBalancerListener]
+	GenericListService[LoadBalancerListener]
+	GenericUpdateService[LoadBalancerListener, LoadBalancerListenerRequest]
+	GenericDeleteService[LoadBalancerListener]
 }

--- a/load_balancer_pools.go
+++ b/load_balancer_pools.go
@@ -28,9 +28,9 @@ type LoadBalancerPoolRequest struct {
 }
 
 type LoadBalancerPoolService interface {
-	GenericCreateService[LoadBalancerPool, LoadBalancerPoolRequest, LoadBalancerPoolRequest]
-	GenericGetService[LoadBalancerPool, LoadBalancerPoolRequest, LoadBalancerPoolRequest]
-	GenericListService[LoadBalancerPool, LoadBalancerPoolRequest, LoadBalancerPoolRequest]
-	GenericUpdateService[LoadBalancerPool, LoadBalancerPoolRequest, LoadBalancerPoolRequest]
-	GenericDeleteService[LoadBalancerPool, LoadBalancerPoolRequest, LoadBalancerPoolRequest]
+	GenericCreateService[LoadBalancerPool, LoadBalancerPoolRequest]
+	GenericGetService[LoadBalancerPool]
+	GenericListService[LoadBalancerPool]
+	GenericUpdateService[LoadBalancerPool, LoadBalancerPoolRequest]
+	GenericDeleteService[LoadBalancerPool]
 }

--- a/load_balancers.go
+++ b/load_balancers.go
@@ -51,9 +51,9 @@ type VIPAddressRequest struct {
 }
 
 type LoadBalancerService interface {
-	GenericCreateService[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]
-	GenericGetService[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]
-	GenericListService[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]
-	GenericUpdateService[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]
-	GenericDeleteService[LoadBalancer, LoadBalancerRequest, LoadBalancerRequest]
+	GenericCreateService[LoadBalancer, LoadBalancerRequest]
+	GenericGetService[LoadBalancer]
+	GenericListService[LoadBalancer]
+	GenericUpdateService[LoadBalancer, LoadBalancerRequest]
+	GenericDeleteService[LoadBalancer]
 }

--- a/networks.go
+++ b/networks.go
@@ -1,9 +1,6 @@
 package cloudscale
 
 import (
-	"context"
-	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -44,94 +41,13 @@ type NetworkUpdateRequest struct {
 }
 
 type NetworkService interface {
-	Create(ctx context.Context, createRequest *NetworkCreateRequest) (*Network, error)
-	Get(ctx context.Context, networkID string) (*Network, error)
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]Network, error)
-	Update(ctx context.Context, networkID string, updateRequest *NetworkUpdateRequest) error
-	Delete(ctx context.Context, networkID string) error
+	GenericCreateService[Network, NetworkCreateRequest, NetworkUpdateRequest]
+	GenericGetService[Network, NetworkCreateRequest, NetworkUpdateRequest]
+	GenericListService[Network, NetworkCreateRequest, NetworkUpdateRequest]
+	GenericUpdateService[Network, NetworkCreateRequest, NetworkUpdateRequest]
+	GenericDeleteService[Network, NetworkCreateRequest, NetworkUpdateRequest]
 }
 
 type NetworkServiceOperations struct {
 	client *Client
-}
-
-func (s NetworkServiceOperations) Create(ctx context.Context, createRequest *NetworkCreateRequest) (*Network, error) {
-	path := networkBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	network := new(Network)
-
-	err = s.client.Do(ctx, req, network)
-	if err != nil {
-		return nil, err
-	}
-
-	return network, nil
-}
-
-func (f NetworkServiceOperations) Update(ctx context.Context, networkID string, updateRequest *NetworkUpdateRequest) error {
-	path := fmt.Sprintf("%s/%s", networkBasePath, networkID)
-
-	req, err := f.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-	if err != nil {
-		return err
-	}
-
-	err = f.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s NetworkServiceOperations) Get(ctx context.Context, networkID string) (*Network, error) {
-	path := fmt.Sprintf("%s/%s", networkBasePath, networkID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	network := new(Network)
-	err = s.client.Do(ctx, req, network)
-	if err != nil {
-		return nil, err
-	}
-
-	return network, nil
-}
-
-func (s NetworkServiceOperations) Delete(ctx context.Context, networkID string) error {
-	path := fmt.Sprintf("%s/%s", networkBasePath, networkID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
-	if err != nil {
-		return err
-	}
-	return s.client.Do(ctx, req, nil)
-}
-
-func (s NetworkServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]Network, error) {
-	path := networkBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	networks := []Network{}
-	err = s.client.Do(ctx, req, &networks)
-	if err != nil {
-		return nil, err
-	}
-
-	return networks, nil
 }

--- a/networks.go
+++ b/networks.go
@@ -41,11 +41,11 @@ type NetworkUpdateRequest struct {
 }
 
 type NetworkService interface {
-	GenericCreateService[Network, NetworkCreateRequest, NetworkUpdateRequest]
-	GenericGetService[Network, NetworkCreateRequest, NetworkUpdateRequest]
-	GenericListService[Network, NetworkCreateRequest, NetworkUpdateRequest]
-	GenericUpdateService[Network, NetworkCreateRequest, NetworkUpdateRequest]
-	GenericDeleteService[Network, NetworkCreateRequest, NetworkUpdateRequest]
+	GenericCreateService[Network, NetworkCreateRequest]
+	GenericGetService[Network]
+	GenericListService[Network]
+	GenericUpdateService[Network, NetworkUpdateRequest]
+	GenericDeleteService[Network]
 }
 
 type NetworkServiceOperations struct {

--- a/objects_users.go
+++ b/objects_users.go
@@ -19,9 +19,9 @@ type ObjectsUserRequest struct {
 
 // ObjectsUsersService manages users of the S3-compatible objects storage
 type ObjectsUsersService interface {
-	GenericCreateService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
-	GenericGetService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
-	GenericListService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
-	GenericUpdateService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
-	GenericDeleteService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
+	GenericCreateService[ObjectsUser, ObjectsUserRequest]
+	GenericGetService[ObjectsUser]
+	GenericListService[ObjectsUser]
+	GenericUpdateService[ObjectsUser, ObjectsUserRequest]
+	GenericDeleteService[ObjectsUser]
 }

--- a/objects_users.go
+++ b/objects_users.go
@@ -1,11 +1,5 @@
 package cloudscale
 
-import (
-	"context"
-	"fmt"
-	"net/http"
-)
-
 const objectsUsersBasePath = "v1/objects-users"
 
 // ObjectsUser contains information
@@ -25,92 +19,9 @@ type ObjectsUserRequest struct {
 
 // ObjectsUsersService manages users of the S3-compatible objects storage
 type ObjectsUsersService interface {
-	Create(ctx context.Context, createRequest *ObjectsUserRequest) (*ObjectsUser, error)
-	Get(ctx context.Context, objectsUserID string) (*ObjectsUser, error)
-	Update(ctx context.Context, objectsUserID string, updateRequest *ObjectsUserRequest) error
-	Delete(ctx context.Context, objectsUserID string) error
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]ObjectsUser, error)
-}
-
-// ObjectsUsersServiceOperations contains config for this service
-type ObjectsUsersServiceOperations struct {
-	client *Client
-}
-
-// Create an objects user with the specified attributes.
-func (s ObjectsUsersServiceOperations) Create(ctx context.Context, createRequest *ObjectsUserRequest) (*ObjectsUser, error) {
-	path := objectsUsersBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	objectsUser := new(ObjectsUser)
-	err = s.client.Do(ctx, req, objectsUser)
-	if err != nil {
-		return nil, err
-	}
-
-	return objectsUser, nil
-}
-
-// Update the properties of an objects user
-func (s ObjectsUsersServiceOperations) Update(ctx context.Context, objectsUserID string, updateRequest *ObjectsUserRequest) error {
-	path := fmt.Sprintf("%s/%s", objectsUsersBasePath, objectsUserID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-	if err != nil {
-		return err
-	}
-
-	err = s.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// Get an objects user by its ID
-func (s ObjectsUsersServiceOperations) Get(ctx context.Context, objectsUserID string) (*ObjectsUser, error) {
-	path := fmt.Sprintf("%s/%s", objectsUsersBasePath, objectsUserID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	objectsUser := new(ObjectsUser)
-	err = s.client.Do(ctx, req, objectsUser)
-	if err != nil {
-		return nil, err
-	}
-
-	return objectsUser, nil
-}
-
-// Delete an objects user
-func (s ObjectsUsersServiceOperations) Delete(ctx context.Context, objectsUserID string) error {
-	return genericDelete(s.client, ctx, objectsUsersBasePath, objectsUserID)
-}
-
-// List all objects users
-func (s ObjectsUsersServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]ObjectsUser, error) {
-	path := objectsUsersBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	ObjectsUser := []ObjectsUser{}
-	err = s.client.Do(ctx, req, &ObjectsUser)
-	if err != nil {
-		return nil, err
-	}
-
-	return ObjectsUser, nil
+	GenericCreateService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
+	GenericGetService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
+	GenericListService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
+	GenericUpdateService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
+	GenericDeleteService[ObjectsUser, ObjectsUserRequest, ObjectsUserRequest]
 }

--- a/server_groups.go
+++ b/server_groups.go
@@ -1,11 +1,5 @@
 package cloudscale
 
-import (
-	"context"
-	"fmt"
-	"net/http"
-)
-
 const serverGroupsBasePath = "v1/server-groups"
 
 type ServerGroup struct {
@@ -21,88 +15,14 @@ type ServerGroup struct {
 type ServerGroupRequest struct {
 	ZonalResourceRequest
 	TaggedResourceRequest
-	Name    string       `json:"name,omitempty"`
-	Type    string       `json:"type,omitempty"`
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
 }
 
 type ServerGroupService interface {
-	Create(ctx context.Context, createRequest *ServerGroupRequest) (*ServerGroup, error)
-	Get(ctx context.Context, serverGroupID string) (*ServerGroup, error)
-	Update(ctx context.Context, networkID string, updateRequest *ServerGroupRequest) error
-	Delete(ctx context.Context, serverGroupID string) error
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]ServerGroup, error)
-}
-
-type ServerGroupServiceOperations struct {
-	client *Client
-}
-
-func (s ServerGroupServiceOperations) Create(ctx context.Context, createRequest *ServerGroupRequest) (*ServerGroup, error) {
-	req, err := s.client.NewRequest(ctx, http.MethodPost, serverGroupsBasePath, createRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	serverGroup := new(ServerGroup)
-	err = s.client.Do(ctx, req, serverGroup)
-	if err != nil {
-		return nil, err
-	}
-
-	return serverGroup, nil
-}
-
-func (s ServerGroupServiceOperations) Get(ctx context.Context, serverGroupID string) (*ServerGroup, error) {
-	path := fmt.Sprintf("%s/%s", serverGroupsBasePath, serverGroupID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	serverGroup := new(ServerGroup)
-	err = s.client.Do(ctx, req, serverGroup)
-	if err != nil {
-		return nil, err
-	}
-
-	return serverGroup, nil
-}
-
-func (f ServerGroupServiceOperations) Update(ctx context.Context, serverGroupID string, updateRequest *ServerGroupRequest) error {
-	path := fmt.Sprintf("%s/%s", serverGroupsBasePath, serverGroupID)
-
-	req, err := f.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-	if err != nil {
-		return err
-	}
-
-	err = f.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s ServerGroupServiceOperations) Delete(ctx context.Context, serverGroupID string) error {
-	return genericDelete(s.client, ctx, serverGroupsBasePath, serverGroupID)
-}
-
-func (s ServerGroupServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]ServerGroup, error) {
-	req, err := s.client.NewRequest(ctx, http.MethodGet, serverGroupsBasePath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	serverGroups := []ServerGroup{}
-	err = s.client.Do(ctx, req, &serverGroups)
-	if err != nil {
-		return nil, err
-	}
-
-	return serverGroups, nil
+	GenericCreateService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
+	GenericGetService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
+	GenericListService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
+	GenericUpdateService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
+	GenericDeleteService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
 }

--- a/server_groups.go
+++ b/server_groups.go
@@ -20,9 +20,9 @@ type ServerGroupRequest struct {
 }
 
 type ServerGroupService interface {
-	GenericCreateService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
-	GenericGetService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
-	GenericListService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
-	GenericUpdateService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
-	GenericDeleteService[ServerGroup, ServerGroupRequest, ServerGroupRequest]
+	GenericCreateService[ServerGroup, ServerGroupRequest]
+	GenericGetService[ServerGroup]
+	GenericListService[ServerGroup]
+	GenericUpdateService[ServerGroup, ServerGroupRequest]
+	GenericDeleteService[ServerGroup]
 }

--- a/subnets.go
+++ b/subnets.go
@@ -100,11 +100,11 @@ func (request SubnetCreateRequest) MarshalJSON() ([]byte, error) {
 }
 
 type SubnetService interface {
-	GenericCreateService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
-	GenericGetService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
-	GenericListService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
-	GenericUpdateService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
-	GenericDeleteService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
+	GenericCreateService[Subnet, SubnetCreateRequest]
+	GenericGetService[Subnet]
+	GenericListService[Subnet]
+	GenericUpdateService[Subnet, SubnetUpdateRequest]
+	GenericDeleteService[Subnet]
 }
 
 type SubnetServiceOperations struct {

--- a/subnets.go
+++ b/subnets.go
@@ -1,10 +1,7 @@
 package cloudscale
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"reflect"
 )
 
@@ -103,94 +100,13 @@ func (request SubnetCreateRequest) MarshalJSON() ([]byte, error) {
 }
 
 type SubnetService interface {
-	Create(ctx context.Context, createRequest *SubnetCreateRequest) (*Subnet, error)
-	Get(ctx context.Context, subnetID string) (*Subnet, error)
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]Subnet, error)
-	Update(ctx context.Context, subnetID string, updateRequest *SubnetUpdateRequest) error
-	Delete(ctx context.Context, subnetID string) error
+	GenericCreateService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
+	GenericGetService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
+	GenericListService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
+	GenericUpdateService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
+	GenericDeleteService[Subnet, SubnetCreateRequest, SubnetUpdateRequest]
 }
 
 type SubnetServiceOperations struct {
 	client *Client
-}
-
-func (s SubnetServiceOperations) Create(ctx context.Context, createRequest *SubnetCreateRequest) (*Subnet, error) {
-	path := subnetBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	subnet := new(Subnet)
-
-	err = s.client.Do(ctx, req, subnet)
-	if err != nil {
-		return nil, err
-	}
-
-	return subnet, nil
-}
-
-func (s SubnetServiceOperations) Update(ctx context.Context, subnetID string, updateRequest *SubnetUpdateRequest) error {
-	path := fmt.Sprintf("%s/%s", subnetBasePath, subnetID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-	if err != nil {
-		return err
-	}
-
-	err = s.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s SubnetServiceOperations) Get(ctx context.Context, subnetID string) (*Subnet, error) {
-	path := fmt.Sprintf("%s/%s", subnetBasePath, subnetID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	subnet := new(Subnet)
-	err = s.client.Do(ctx, req, subnet)
-	if err != nil {
-		return nil, err
-	}
-
-	return subnet, nil
-}
-
-func (s SubnetServiceOperations) Delete(ctx context.Context, subnetID string) error {
-	path := fmt.Sprintf("%s/%s", subnetBasePath, subnetID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
-	if err != nil {
-		return err
-	}
-	return s.client.Do(ctx, req, nil)
-}
-
-func (s SubnetServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]Subnet, error) {
-	path := subnetBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	subnets := []Subnet{}
-	err = s.client.Do(ctx, req, &subnets)
-	if err != nil {
-		return nil, err
-	}
-
-	return subnets, nil
 }

--- a/volumes.go
+++ b/volumes.go
@@ -1,7 +1,6 @@
 package cloudscale
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -33,98 +32,14 @@ type VolumeRequest struct {
 }
 
 type VolumeService interface {
-	Create(ctx context.Context, createRequest *VolumeRequest) (*Volume, error)
-	Get(ctx context.Context, volumeID string) (*Volume, error)
-	List(ctx context.Context, modifiers ...ListRequestModifier) ([]Volume, error)
-	Update(ctx context.Context, volumeID string, updateRequest *VolumeRequest) error
-	Delete(ctx context.Context, volumeID string) error
+	GenericCreateService[Volume, VolumeRequest]
+	GenericGetService[Volume]
+	GenericListService[Volume]
+	GenericUpdateService[Volume, VolumeRequest]
+	GenericDeleteService[Volume]
 }
 
-type VolumeServiceOperations struct {
-	client *Client
-}
-
-func (s VolumeServiceOperations) Create(ctx context.Context, createRequest *VolumeRequest) (*Volume, error) {
-	path := volumeBasePath
-
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	volume := new(Volume)
-
-	err = s.client.Do(ctx, req, volume)
-	if err != nil {
-		return nil, err
-	}
-
-	return volume, nil
-}
-
-func (f VolumeServiceOperations) Update(ctx context.Context, volumeID string, updateRequest *VolumeRequest) error {
-	path := fmt.Sprintf("%s/%s", volumeBasePath, volumeID)
-
-	req, err := f.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
-	if err != nil {
-		return err
-	}
-
-	err = f.client.Do(ctx, req, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s VolumeServiceOperations) Get(ctx context.Context, volumeID string) (*Volume, error) {
-	path := fmt.Sprintf("%s/%s", volumeBasePath, volumeID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	volume := new(Volume)
-	err = s.client.Do(ctx, req, volume)
-	if err != nil {
-		return nil, err
-	}
-
-	return volume, nil
-}
-
-func (s VolumeServiceOperations) Delete(ctx context.Context, volumeID string) error {
-	path := fmt.Sprintf("%s/%s", volumeBasePath, volumeID)
-
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
-	if err != nil {
-		return err
-	}
-	return s.client.Do(ctx, req, nil)
-}
-
-func (s VolumeServiceOperations) List(ctx context.Context, modifiers ...ListRequestModifier) ([]Volume, error) {
-	path := volumeBasePath
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, modifier := range modifiers {
-		modifier(req)
-	}
-
-	volumes := []Volume{}
-	err = s.client.Do(ctx, req, &volumes)
-	if err != nil {
-		return nil, err
-	}
-
-	return volumes, nil
-}
-
-//WithNameFilter uses an undocumented feature of the cloudscale.ch API
+// WithNameFilter uses an undocumented feature of the cloudscale.ch API
 func WithNameFilter(name string) ListRequestModifier {
 	return func(request *http.Request) {
 		query := request.URL.Query()


### PR DESCRIPTION
This finished as refactoring, that we have started when we introduced load balancers in the sdk. It replaces many duplicated implementations of CRUD methods with a single one.

We didn't know how to this pre Generics in golang.