### PR TITLE
Map the default_username field for images

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -54,6 +54,7 @@ type Image struct {
 	Slug            string `json:"slug"`
 	Name            string `json:"name"`
 	OperatingSystem string `json:"operating_system"`
+	DefaultUsername string `json:"default_username,omitempty"`
 }
 
 type VolumeStub struct {

--- a/servers.go
+++ b/servers.go
@@ -54,7 +54,7 @@ type Image struct {
 	Slug            string `json:"slug"`
 	Name            string `json:"name"`
 	OperatingSystem string `json:"operating_system"`
-	DefaultUsername string `json:"default_username,omitempty"`
+	DefaultUsername string `json:"default_username"`
 }
 
 type VolumeStub struct {

--- a/test/integration/custom_images_integration_test.go
+++ b/test/integration/custom_images_integration_test.go
@@ -186,6 +186,7 @@ func TestIntegrationCustomImage_Boot(t *testing.T) {
 		UserDataHandling: "extend-cloud-config",
 		Zones:            []string{"lpg1", "rma1"},
 		SourceFormat:     "raw",
+		Slug:             "fancy",
 	}
 
 	customImageImport, err := client.CustomImageImports.Create(context.Background(), createCustomImageImportRequest)
@@ -210,6 +211,19 @@ func TestIntegrationCustomImage_Boot(t *testing.T) {
 		t.Fatalf("Servers.Create returned error %s\n", err)
 	}
 	waitUntil("running", server.UUID, t)
+
+	if server.Image.Slug != "custom:fancy" {
+		t.Errorf("Server.Image.Slug got=%s, want=%s", server.Image.Slug, "=custom:fancy")
+	}
+	if server.Image.Name != createCustomImageImportRequest.Name {
+		t.Errorf("Server.Image.Name got=%s, want '%s'", server.Image.Name, createCustomImageImportRequest.Name)
+	}
+	if server.Image.OperatingSystem != "" {
+		t.Errorf("Server.Image.OperatingSystem got=%s, want an empty string", server.Image.OperatingSystem)
+	}
+	if server.Image.DefaultUsername != "" {
+		t.Errorf("Server.Image.DefaultUsername got=%s, want an empty string", server.Image.DefaultUsername)
+	}
 
 	err = client.Servers.Delete(context.Background(), server.UUID)
 	if err != nil {

--- a/test/integration/servers_integration_test.go
+++ b/test/integration/servers_integration_test.go
@@ -57,6 +57,21 @@ func TestIntegrationServer_CRUD(t *testing.T) {
 		t.Errorf("server.CreatedAt ourside of expected range. got=%v", server.CreatedAt)
 	}
 
+	if server.Image.Slug != DefaultImageSlug {
+		t.Errorf("Server.Image.Slug got=%s, want=%s", server.Image.Slug, DefaultImageSlug)
+	}
+
+	const expectedValue = "debian"
+	if !strings.Contains(strings.ToLower(server.Image.Name), expectedValue) {
+		t.Errorf("Server.Image.Name got=%s, want to contain '%s'", server.Image.Name, expectedValue)
+	}
+	if !strings.Contains(strings.ToLower(server.Image.OperatingSystem), expectedValue) {
+		t.Errorf("Server.Image.OperatingSystem got=%s, want to contain '%s'", server.Image.OperatingSystem, expectedValue)
+	}
+	if !strings.Contains(strings.ToLower(server.Image.DefaultUsername), expectedValue) {
+		t.Errorf("Server.Image.DefaultUsername got=%s, want to contain '%s'", server.Image.DefaultUsername, expectedValue)
+	}
+
 	servers, err := client.Servers.List(context.Background())
 	if err != nil {
 		t.Fatalf("Servers.List returned error %s\n", err)


### PR DESCRIPTION
By mapping this field we can use it in our fleeting plugin, where we need that information.