### PR TITLE
Fix handling of empty `AllowedCIDRs` in LoadBalancerListener

### DIFF
--- a/load_balancer_listeners.go
+++ b/load_balancer_listeners.go
@@ -32,14 +32,14 @@ type LoadBalancerListener struct {
 
 type LoadBalancerListenerRequest struct {
 	TaggedResourceRequest
-	Name                   string   `json:"name,omitempty"`
-	Pool                   string   `json:"pool,omitempty"`
-	Protocol               string   `json:"protocol,omitempty"`
-	ProtocolPort           int      `json:"protocol_port,omitempty"`
-	AllowedCIDRs           []string `json:"allowed_cidrs,omitempty"`
-	TimeoutClientDataMS    int      `json:"timeout_client_data_ms,omitempty"`
-	TimeoutMemberConnectMS int      `json:"timeout_member_connect_ms,omitempty"`
-	TimeoutMemberDataMS    int      `json:"timeout_member_data_ms,omitempty"`
+	Name                   string    `json:"name,omitempty"`
+	Pool                   string    `json:"pool,omitempty"`
+	Protocol               string    `json:"protocol,omitempty"`
+	ProtocolPort           int       `json:"protocol_port,omitempty"`
+	AllowedCIDRs           *[]string `json:"allowed_cidrs,omitempty"`
+	TimeoutClientDataMS    int       `json:"timeout_client_data_ms,omitempty"`
+	TimeoutMemberConnectMS int       `json:"timeout_member_connect_ms,omitempty"`
+	TimeoutMemberDataMS    int       `json:"timeout_member_data_ms,omitempty"`
 }
 
 type LoadBalancerListenerService interface {

--- a/test/integration/load_balancer_listeners_integration_test.go
+++ b/test/integration/load_balancer_listeners_integration_test.go
@@ -150,7 +150,7 @@ func TestIntegrationLoadBalancerListener_Update(t *testing.T) {
 	// update allowed ciders
 	updatedAllowedCIDRs := []string{"10.0.0.0/24"}
 	updateRequest2 := &cloudscale.LoadBalancerListenerRequest{
-		AllowedCIDRs: updatedAllowedCIDRs,
+		AllowedCIDRs: &updatedAllowedCIDRs,
 	}
 
 	err = client.LoadBalancerListeners.Update(context.Background(), uuid, updateRequest2)
@@ -170,7 +170,7 @@ func TestIntegrationLoadBalancerListener_Update(t *testing.T) {
 	// set allowed CIDRs to an empty list
 	updatedAllowedCIDRsEmpty := []string{}
 	updateRequest3 := &cloudscale.LoadBalancerListenerRequest{
-		AllowedCIDRs: updatedAllowedCIDRsEmpty,
+		AllowedCIDRs: &updatedAllowedCIDRsEmpty,
 	}
 
 	err = client.LoadBalancerListeners.Update(context.Background(), uuid, updateRequest3)

--- a/test/integration/load_balancer_listeners_integration_test.go
+++ b/test/integration/load_balancer_listeners_integration_test.go
@@ -167,6 +167,26 @@ func TestIntegrationLoadBalancerListener_Update(t *testing.T) {
 		t.Errorf("updated2.AllowedCIDRs \n got=%s\nwant=%s", allowedCIDRs, updatedAllowedCIDRs)
 	}
 
+	// set allowed CIDRs to an empty list
+	updatedAllowedCIDRsEmpty := []string{}
+	updateRequest3 := &cloudscale.LoadBalancerListenerRequest{
+		AllowedCIDRs: updatedAllowedCIDRsEmpty,
+	}
+
+	err = client.LoadBalancerListeners.Update(context.Background(), uuid, updateRequest3)
+	if err != nil {
+		t.Fatalf("LoadBalancerListeners.Update returned error %s\n", err)
+	}
+
+	updated3, err := client.LoadBalancerListeners.Get(context.Background(), uuid)
+	if err != nil {
+		t.Fatalf("LoadBalancerListeners.Get returned error %s\n", err)
+	}
+
+	if allowedCIDRs := updated3.AllowedCIDRs; !reflect.DeepEqual(allowedCIDRs, updatedAllowedCIDRsEmpty) {
+		t.Errorf("updated3.AllowedCIDRs \n got=%s\nwant=%s", allowedCIDRs, updatedAllowedCIDRsEmpty)
+	}
+
 	err = client.LoadBalancerListeners.Delete(context.Background(), updated.UUID)
 	if err != nil {
 		t.Fatalf("LoadBalancerListeners.Delete returned error %s\n", err)


### PR DESCRIPTION
This is required to fix https://github.com/cloudscale-ch/cloudscale-cloud-controller-manager/issues/19

- Updated the `AllowedCIDRs` field in `LoadBalancerListenerRequest` to a pointer (`[]string` to `*[]string`) to correctly handle the case of empty CIDR lists.
- Added an integration test to ensure the `AllowedCIDRs` field can be set to an empty list without errors.
