### PR TITLE
Adjust Expected Error Message in Integration Test

### DIFF
--- a/test/integration/servers_integration_test.go
+++ b/test/integration/servers_integration_test.go
@@ -203,7 +203,7 @@ func TestIntegrationServer_UpdateRest(t *testing.T) {
 	if err == nil {
 		t.Error("Expected an error when updating multiple volume attributes\n")
 	} else {
-		expected := "To keep changes atomic"
+		expected := "Only one attribute"
 		err, ok := err.(*cloudscale.ErrorResponse)
 		if !ok {
 			t.Errorf("Couldn't cast %s\n", err)

--- a/test/integration/volumes_integration_test.go
+++ b/test/integration/volumes_integration_test.go
@@ -118,7 +118,7 @@ func TestIntegrationVolume_CreateWithoutServer(t *testing.T) {
 	if err == nil {
 		t.Error("Expected an error when updating multiple volume attributes\n")
 	} else {
-		expected := "To keep changes atomic"
+		expected := "Only one attribute"
 		err, ok := err.(*cloudscale.ErrorResponse)
 		if !ok {
 			t.Errorf("Couldn't cast %s\n", err)


### PR DESCRIPTION
The error message string was reworded recently in the backend. 

This only affects test code, no need to create a new release.