### PR TITLE
Fix Structure of VolumeSnapshot.SourceVolume

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -58,10 +58,11 @@ type ImageServerStub struct {
 }
 
 type VolumeStub struct {
-	Type       string `json:"type"`
-	DevicePath string `json:"device_path"`
-	SizeGB     int    `json:"size_gb"`
-	UUID       string `json:"uuid"`
+	HREF   string `json:"href"`
+	UUID   string `json:"uuid"`
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	SizeGB int    `json:"size_gb"`
 }
 
 type Interface struct {

--- a/test/integration/servers_integration_test.go
+++ b/test/integration/servers_integration_test.go
@@ -352,6 +352,15 @@ func TestIntegrationServer_MultipleVolumes(t *testing.T) {
 		t.Errorf("Volumes response\n got=%#v\nwant=%#v", actual, expected)
 	}
 
+	for _, volume := range server.Volumes {
+		if volume.HREF == "" {
+			t.Errorf("Expected volume HREF to be non-empty for UUID %s", volume.UUID)
+		}
+		if volume.Name == "" {
+			t.Errorf("Expected volume Name to be non-empty for UUID %s", volume.UUID)
+		}
+	}
+
 	// delete all volume, except the root volume
 	for _, volume := range server.Volumes[1:] {
 		volumeUUID := volume.UUID

--- a/test/integration/servers_integration_test.go
+++ b/test/integration/servers_integration_test.go
@@ -337,16 +337,18 @@ func TestIntegrationServer_MultipleVolumes(t *testing.T) {
 		t.Fatalf("Servers.WaitFor returned error %s\n", err)
 	}
 
-	// Ignore UUIDs in this comparison
+	// Ignore instance-specific fields in this comparison
 	actual := make([]cloudscale.VolumeStub, len(server.Volumes))
 	copy(actual, server.Volumes)
 	for i := range actual {
 		actual[i].UUID = ""
+		actual[i].HREF = ""
+		actual[i].Name = ""
 	}
 	expected := []cloudscale.VolumeStub{
-		{Type: "ssd", DevicePath: "", SizeGB: 10, UUID: ""},
-		{Type: "ssd", DevicePath: "", SizeGB: 3, UUID: ""},
-		{Type: "bulk", DevicePath: "", SizeGB: 100, UUID: ""},
+		{Type: "ssd", SizeGB: 10},
+		{Type: "ssd", SizeGB: 3},
+		{Type: "bulk", SizeGB: 100},
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Volumes response\n got=%#v\nwant=%#v", actual, expected)

--- a/test/integration/volume_snapshots_integration_test.go
+++ b/test/integration/volume_snapshots_integration_test.go
@@ -53,6 +53,12 @@ func TestIntegrationVolumeSnapshot_CRUD(t *testing.T) {
 	if retrieved.SourceVolume.UUID != volume.UUID {
 		t.Errorf("Expected retrieved snapshot SourceVolume.UUID to be %s, got %q", volume.UUID, retrieved.SourceVolume.UUID)
 	}
+	if retrieved.SourceVolume.Name != volume.Name {
+		t.Errorf("Expected SourceVolume.Name %q, got %q", volume.Name, retrieved.SourceVolume.Name)
+	}
+	if retrieved.SourceVolume.HREF == "" {
+		t.Error("Expected SourceVolume.HREF to be non-empty")
+	}
 
 	snapshots, err := client.VolumeSnapshots.List(ctx)
 	if err != nil {

--- a/volume_snapshots.go
+++ b/volume_snapshots.go
@@ -2,16 +2,22 @@ package cloudscale
 
 const volumeSnapshotsBasePath = "v1/volume-snapshots"
 
+type SourceVolumeStub struct {
+	HREF string `json:"href"`
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
 type VolumeSnapshot struct {
 	ZonalResource
 	TaggedResource
-	HREF         string     `json:"href,omitempty"`
-	UUID         string     `json:"uuid,omitempty"`
-	Name         string     `json:"name,omitempty"`
-	SizeGB       int        `json:"size_gb,omitempty"`
-	CreatedAt    string     `json:"created_at,omitempty"`
-	SourceVolume VolumeStub `json:"source_volume,omitempty"`
-	Status       string     `json:"status,omitempty"`
+	HREF         string           `json:"href,omitempty"`
+	UUID         string           `json:"uuid,omitempty"`
+	Name         string           `json:"name,omitempty"`
+	SizeGB       int              `json:"size_gb,omitempty"`
+	CreatedAt    string           `json:"created_at,omitempty"`
+	SourceVolume SourceVolumeStub `json:"source_volume,omitempty"`
+	Status       string           `json:"status,omitempty"`
 }
 
 type VolumeSnapshotCreateRequest struct {


### PR DESCRIPTION
  Two related struct fixes, both proven by failing integration tests first.                   
                                                                                              
 **SourceVolumeStub** (VolumeSnapshot.SourceVolume) — the API returns only `href`, `uuid`, `name` in `source_volume`. Reusing `VolumeStub` there was structurally wrong. Introduces `SourceVolumeStub` matching the actual API shape;                         
  `VolumeSnapshot.SourceVolume` is updated to use it.                                         
                                                                                              
**VolumeStub** (Server.Volumes) — the API returns `href`, `uuid`, `name`, `type`, `size_gb`. `VolumeStub` was missing `href`/`name` and carried a `device_path` field the API never returns. Both are corrected.                            
                                                                                              
  Breaking changes → requires v9.    