### PR TITLE
test: use same domain for invalid image URL constant

### DIFF
--- a/test/integration/custom_images_integration_test.go
+++ b/test/integration/custom_images_integration_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 const testImageURL = "https://at-images.objects.lpg.cloudscale.ch/prod/alpine.raw"
+const testInvalidImageURL = "https://at-images.objects.lpg.cloudscale.ch/prod/this-does-and-will-never-exist"
 
 func TestIntegrationCustomImage_CRUD(t *testing.T) {
 	t.Parallel()
@@ -123,7 +124,7 @@ func TestIntegrationCustomImage_InvalidURL(t *testing.T) {
 
 	createCustomImageRequest := &cloudscale.CustomImageImportRequest{
 		Name:             testRunPrefix,
-		URL:              "http://www.cloudscale.ch/this-does-and-will-never-exist",
+		URL:              testInvalidImageURL,
 		UserDataHandling: "extend-cloud-config",
 		Zones:            []string{"rma1"},
 		SourceFormat:     "raw",

--- a/test/integration/custom_images_integration_test.go
+++ b/test/integration/custom_images_integration_test.go
@@ -143,9 +143,9 @@ func TestIntegrationCustomImage_InvalidURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CustomImageImports.WaitFor returned error %s\n", err)
 	}
-	expectedMessage := "Expected HTTP 200, got HTTP 404"
-	if errorMessage := customImageImport.ErrorMessage; errorMessage != expectedMessage {
-		t.Errorf("customImageImport.ErrorMessage got=%s\nwant=%s\n", errorMessage, expectedMessage)
+	expectedPrefix := "Expected HTTP 200, got HTTP 4"
+	if errorMessage := customImageImport.ErrorMessage; !strings.HasPrefix(errorMessage, expectedPrefix) {
+		t.Errorf("customImageImport.ErrorMessage got=%s\nwant prefix %s\n", errorMessage, expectedPrefix)
 	}
 }
 


### PR DESCRIPTION
Use the same at-images.objects.lpg.cloudscale.ch/prod/ base as the valid test image URL, and extract it into a named constant.